### PR TITLE
내가 속한 로드맵 목록 조회, 로드맵 전체 목록 조회 기능 

### DIFF
--- a/src/main/java/com/example/tily/TiLyApplication.java
+++ b/src/main/java/com/example/tily/TiLyApplication.java
@@ -41,38 +41,60 @@ public class TiLyApplication {
 			userRepository.saveAll(Arrays.asList(
 					newUser("tngus@test.com", "su", passwordEncoder, Role.ROLE_USER),
 					newUser("hong@naver.com", "hong", passwordEncoder, Role.ROLE_USER),
-					newUser("test@test.com", "hongHong", passwordEncoder, Role.ROLE_USER),
+					newUser("test@test.com", "test", passwordEncoder, Role.ROLE_USER),
 					newUser("admin@test.com", "admin", passwordEncoder, Role.ROLE_ADMIN)
 			));
 			roadmapRepository.saveAll(Arrays.asList(
-					newIndividualRoadmap(User.builder().id(1L).build(), Category.CATEGORY_INDIVIDUAL, "스프링 시큐리티", 10L),
+					newIndividualRoadmap(User.builder().id(1L).build(), Category.CATEGORY_INDIVIDUAL, "스프링 시큐리티", 10L), //1
 					newIndividualRoadmap(User.builder().id(2L).build(),Category.CATEGORY_INDIVIDUAL, "JPA 입문", 10L),
 					newIndividualRoadmap(User.builder().id(3L).build(),Category.CATEGORY_INDIVIDUAL, "자바 reflection", 10L),
-					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILLY, "spring boot - 초급편", "틸리에서 제공하는 spring boot 초급자를 위한 로드맵입니다.", 100L, 20L, "image.jpg"),
-					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILLY, "spring boot - 중급편", "틸리에서 제공하는 spring boot 중급자를 위한 로드맵입니다.", 80L, 30L , "image.jpg"),
-					newGroupRoadmap(User.builder().id(1L).build(), Category.CATEGORY_GROUP, "JAVA 입문 수업 - 생활 코딩", "생활 코딩님의 로드맵입니다!", true, 3L, "pnu1234", true, 3L),
-					newGroupRoadmap(User.builder().id(2L).build(), Category.CATEGORY_GROUP, "JPA 스터디", "김영한 강사님의 JPA를 공부하는 스터디 ^^", false, 10L, "ashfkc", true, 10L)
-			));
+
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "spring boot - 초급편", "틸리에서 제공하는 spring boot 초급자를 위한 로드맵입니다.", 100L, 20L, "image.jpg"), //4
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "spring boot - 중급편", "틸리에서 제공하는 spring boot 중급자를 위한 로드맵입니다.", 80L, 30L , "image.jpg"),
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "spring boot - 고급편", "틸리에서 제공하는 spring boot 고급자를 위한 로드맵입니다.", 50L, 30L , "image.jpg"),
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "Spring JPA - 초급편", "틸리에서 제공하는 Spring JPA 초급자를 위한 로드맵입니다.", 100L, 20L , "image.jpg"),
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "Spring JPA - 중급편", "틸리에서 제공하는 Spring JPA 중급자를 위한 로드맵입니다.", 80L, 20L , "image.jpg"),
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "Spring JPA - 고급편", "틸리에서 제공하는 Spring JPA 고급자를 위한 로드맵입니다.", 50L, 20L , "image.jpg"),
+
+					newGroupRoadmap(User.builder().id(1L).build(), Category.CATEGORY_GROUP, "JAVA 입문 수업 - 생활 코딩", "생활 코딩님의 로드맵입니다!", true, 5L, "pnu1234", true, 10L), // 10
+					newGroupRoadmap(User.builder().id(1L).build(), Category.CATEGORY_GROUP, "spring boot 스터디", "같이 spring boot 공부해봐요!", true, 3L, "pnu1234", true, 10L),
+					newGroupRoadmap(User.builder().id(2L).build(), Category.CATEGORY_GROUP, "JPA 스터디", "김영한 강사님의 JPA를 공부하는 스터디 ^^", false, 5L, "ashfkc", false, 20L),
+					newGroupRoadmap(User.builder().id(2L).build(), Category.CATEGORY_GROUP, "데이터베이스 스터디", "데이터베이스 공부합시다", true, 8L, "asdf", true, 15L),
+					newGroupRoadmap(User.builder().id(3L).build(), Category.CATEGORY_GROUP, "카카오테크캠퍼스 1단계", "카카오테크캠퍼스 1단계입니다.", false, 50L, "kakao", true, 20L)
+
+					));
 			userRoadmapRepository.saveAll(Arrays.asList(
 					newUserRoadmapRelation(Roadmap.builder().id(1L).build(), User.builder().id(1L).build(), null, null, "master", 0),
 					newUserRoadmapRelation(Roadmap.builder().id(2L).build(), User.builder().id(2L).build(), null, null, "master", 0),
 					newUserRoadmapRelation(Roadmap.builder().id(3L).build(), User.builder().id(3L).build(), null, null, "master", 0),
+
 					newUserRoadmapRelation(Roadmap.builder().id(4L).build(), User.builder().id(4L).build(), null, true, "master", 10),
 					newUserRoadmapRelation(Roadmap.builder().id(4L).build(), User.builder().id(1L).build(), null, true, "member", 10),
 					newUserRoadmapRelation(Roadmap.builder().id(4L).build(), User.builder().id(2L).build(), null, true, "member", 20),
 					newUserRoadmapRelation(Roadmap.builder().id(4L).build(), User.builder().id(3L).build(), null, true, "member", 100),
-					newUserRoadmapRelation(Roadmap.builder().id(6L).build(), User.builder().id(1L).build(), "자바 공부하고싶습니다!", true, "member", 10),
-					newUserRoadmapRelation(Roadmap.builder().id(6L).build(), User.builder().id(2L).build(), "자바 공부하고싶습니다!", true, "member", 10),
-					newUserRoadmapRelation(Roadmap.builder().id(6L).build(), User.builder().id(3L).build(), "자바 공부하고싶습니다!", false, "none", 0),
-					newUserRoadmapRelation(Roadmap.builder().id(7L).build(), User.builder().id(1L).build(), "자바 공부하고싶습니다!", true, "member", 0)
-			));
+					newUserRoadmapRelation(Roadmap.builder().id(5L).build(), User.builder().id(4L).build(), null, true, "master", 0),
+					newUserRoadmapRelation(Roadmap.builder().id(6L).build(), User.builder().id(4L).build(), null, true, "master", 0),
+					newUserRoadmapRelation(Roadmap.builder().id(7L).build(), User.builder().id(4L).build(), null, true, "master", 0),
+					newUserRoadmapRelation(Roadmap.builder().id(7L).build(), User.builder().id(1L).build(), null, true, "member", 100),
+					newUserRoadmapRelation(Roadmap.builder().id(7L).build(), User.builder().id(2L).build(), null, true, "member", 20),
+					newUserRoadmapRelation(Roadmap.builder().id(7L).build(), User.builder().id(3L).build(), null, true, "member", 100),
+					newUserRoadmapRelation(Roadmap.builder().id(8L).build(), User.builder().id(4L).build(), null, true, "master", 0),
+					newUserRoadmapRelation(Roadmap.builder().id(9L).build(), User.builder().id(4L).build(), null, true, "master", 0),
+
+					newUserRoadmapRelation(Roadmap.builder().id(10L).build(), User.builder().id(2L).build(), "자바 공부하고싶습니다!", true, "member", 10),
+					newUserRoadmapRelation(Roadmap.builder().id(10L).build(), User.builder().id(3L).build(), "자바 공부하고싶습니다!", true, "member", 10),
+					newUserRoadmapRelation(Roadmap.builder().id(12L).build(), User.builder().id(1L).build(), "열심히 하겠습니다!", false, "none", 0),
+					newUserRoadmapRelation(Roadmap.builder().id(12L).build(), User.builder().id(3L).build(), "열심히 하겠습니다!", true, "member", 0),
+					newUserRoadmapRelation(Roadmap.builder().id(13L).build(), User.builder().id(1L).build(), "열심히 하겠습니다!", true, "member", 20)
+					));
 			stepRepository.saveAll(Arrays.asList(
 					newIndividualStep(Roadmap.builder().id(1L).build(), "스프링 시큐리티를 사용하는 이유"),
 					newIndividualStep(Roadmap.builder().id(1L).build(), "OAuth 2.0으로 로그인 기능 구현하기"),
 					newIndividualStep(Roadmap.builder().id(1L).build(), "인증된 사용자 권한 부족 예외처리"),
-					newGroupStep(Roadmap.builder().id(4L).build(),"다형성(Polymorphism)", "Day1", LocalDateTime.of(2023, 10, 1, 23 ,59) ),
-					newGroupStep(Roadmap.builder().id(4L).build(),"람다식(lambda expression)", "Day2", LocalDateTime.of(2023, 10, 3, 23 ,59) ),
-					newGroupStep(Roadmap.builder().id(7L).build(),"스트림(lambda expression)", "Day3", LocalDateTime.of(2023, 10, 5, 23 ,59) )
+
+					newGroupStep(Roadmap.builder().id(12L).build(),"다형성(Polymorphism)", "Day1", LocalDateTime.of(2023, 10, 1, 23 ,59) ),
+					newGroupStep(Roadmap.builder().id(12L).build(),"람다식(lambda expression)", "Day2", LocalDateTime.of(2023, 10, 3, 23 ,59) ),
+					newGroupStep(Roadmap.builder().id(12L).build(),"스트림(lambda expression)", "Day3", LocalDateTime.of(2023, 10, 5, 23 ,59) )
 			));
 			referenceRepository.saveAll(Arrays.asList(
 					newReference(Step.builder().id(4L).build(), "youtube", "https://www.youtube.com/watch?v=0L6QWKC1a6k"),

--- a/src/main/java/com/example/tily/TiLyApplication.java
+++ b/src/main/java/com/example/tily/TiLyApplication.java
@@ -72,15 +72,15 @@ public class TiLyApplication {
 					newIndividualStep(Roadmap.builder().id(1L).build(), "인증된 사용자 권한 부족 예외처리"),
 					newGroupStep(Roadmap.builder().id(4L).build(),"다형성(Polymorphism)", "Day1", LocalDateTime.of(2023, 10, 1, 23 ,59) ),
 					newGroupStep(Roadmap.builder().id(4L).build(),"람다식(lambda expression)", "Day2", LocalDateTime.of(2023, 10, 3, 23 ,59) ),
-					newGroupStep(Roadmap.builder().id(5L).build(),"스트림(lambda expression)", "Day3", LocalDateTime.of(2023, 10, 5, 23 ,59) )
+					newGroupStep(Roadmap.builder().id(7L).build(),"스트림(lambda expression)", "Day3", LocalDateTime.of(2023, 10, 5, 23 ,59) )
 			));
 			referenceRepository.saveAll(Arrays.asList(
 					newReference(Step.builder().id(4L).build(), "youtube", "https://www.youtube.com/watch?v=0L6QWKC1a6k"),
-					newReference(Step.builder().id(5L).build(), "youtube", "https://www.youtube.com/watch?v=U8LVCTaS3mQ"),
+					newReference(Step.builder().id(4L).build(), "youtube", "https://www.youtube.com/watch?v=U8LVCTaS3mQ"),
 					newReference(Step.builder().id(6L).build(), "youtube", "https://www.youtube.com/watch?v=1OLy4Dj_zCg"),
 					newReference(Step.builder().id(4L).build(), "web", "https://blog.naver.com/hoyai-/1234"),
 					newReference(Step.builder().id(5L).build(), "web", "https://blog.naver.com/cestlavie_01/1234"),
-					newReference(Step.builder().id(6L).build(), "web", "https://velog.io/@skydoves/open-source-machenism")
+					newReference(Step.builder().id(5L).build(), "web", "https://velog.io/@skydoves/open-source-machenism")
 			));
 			tilRepository.saveAll(Arrays.asList(
 					newTil(Step.builder().id(1L).build(), "10월 1일의 TIL", "이것은 내용입니다.", false, "이것은 제출할 내용입니다.")

--- a/src/main/java/com/example/tily/roadmap/Category.java
+++ b/src/main/java/com/example/tily/roadmap/Category.java
@@ -8,6 +8,6 @@ import lombok.Getter;
 public enum Category {
     CATEGORY_INDIVIDUAL("individual"),
     CATEGORY_GROUP("group"),
-    CATEGORY_TILLY("tilly");
+    CATEGORY_TILY("tily");
     private String value;
 }

--- a/src/main/java/com/example/tily/roadmap/Category.java
+++ b/src/main/java/com/example/tily/roadmap/Category.java
@@ -1,7 +1,14 @@
 package com.example.tily.roadmap;
 
+import com.example.tily._core.errors.exception.Exception400;
+import com.example.tily._core.errors.exception.Exception404;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @AllArgsConstructor
 @Getter
@@ -9,5 +16,19 @@ public enum Category {
     CATEGORY_INDIVIDUAL("individual"),
     CATEGORY_GROUP("group"),
     CATEGORY_TILY("tily");
+
     private String value;
+
+    public String getString(Category category) {
+        return this.value;
+    }
+
+    public static Category getCategory(String category) {
+        if (category.equals("individual"))
+            return CATEGORY_INDIVIDUAL;
+        else if (category.equals("group"))
+            return CATEGORY_GROUP;
+        else
+            return CATEGORY_TILY;
+    }
 }

--- a/src/main/java/com/example/tily/roadmap/Roadmap.java
+++ b/src/main/java/com/example/tily/roadmap/Roadmap.java
@@ -1,15 +1,12 @@
 package com.example.tily.roadmap;
 
-import com.example.tily.step.UserStepRelation;
+import com.example.tily.roadmap.relation.UserRoadmap;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 import javax.persistence.*;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -23,7 +20,7 @@ public class Roadmap {
     private Long id;
 
     @OneToMany(mappedBy =  "roadmap")
-    private List<UserRoadmapRelation> userRoadmapRelations = new ArrayList<>();
+    private List<UserRoadmap> userRoadmaps = new ArrayList<>();
 
     @Column(nullable = false)
     private String creator;

--- a/src/main/java/com/example/tily/roadmap/Roadmap.java
+++ b/src/main/java/com/example/tily/roadmap/Roadmap.java
@@ -1,5 +1,6 @@
 package com.example.tily.roadmap;
 
+import com.example.tily.BaseTimeEntity;
 import com.example.tily.roadmap.relation.UserRoadmap;
 import com.example.tily.user.User;
 import lombok.AccessLevel;
@@ -15,7 +16,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name="roadmap_tb")
-public class Roadmap {
+public class Roadmap extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/tily/roadmap/Roadmap.java
+++ b/src/main/java/com/example/tily/roadmap/Roadmap.java
@@ -1,6 +1,7 @@
 package com.example.tily.roadmap;
 
 import com.example.tily.roadmap.relation.UserRoadmap;
+import com.example.tily.user.User;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,8 +23,11 @@ public class Roadmap {
     @OneToMany(mappedBy =  "roadmap")
     private List<UserRoadmap> userRoadmaps = new ArrayList<>();
 
-    @Column(nullable = false)
-    private String creator;
+    @ManyToOne
+    @JoinColumn(name = "creator_id")
+    private User creator;
+
+    @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     private Category category;
     @Column(nullable = false)
@@ -42,7 +46,7 @@ public class Roadmap {
     private Long stepNum;
 
     @Builder
-    public Roadmap(Long id, String creator, Category category, String name, String description, Boolean isPublic, Long currentNum, String code, Boolean isRecruit, Long stepNum) {
+    public Roadmap(Long id, User creator, Category category, String name, String description, Boolean isPublic, Long currentNum, String code, Boolean isRecruit, Long stepNum) {
         this.id = id;
         this.creator = creator;
         this.category = category;

--- a/src/main/java/com/example/tily/roadmap/Roadmap.java
+++ b/src/main/java/com/example/tily/roadmap/Roadmap.java
@@ -20,8 +20,8 @@ public class Roadmap {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy =  "roadmap")
-    private List<UserRoadmap> userRoadmaps = new ArrayList<>();
+//    @OneToMany(mappedBy =  "roadmap")
+//    private List<UserRoadmap> userRoadmaps = new ArrayList<>();
 
     @ManyToOne
     @JoinColumn(name = "creator_id")

--- a/src/main/java/com/example/tily/roadmap/Roadmap.java
+++ b/src/main/java/com/example/tily/roadmap/Roadmap.java
@@ -44,9 +44,11 @@ public class Roadmap {
     private Boolean isRecruit;
     @Column
     private Long stepNum;
+    @Column
+    private String image;
 
     @Builder
-    public Roadmap(Long id, User creator, Category category, String name, String description, Boolean isPublic, Long currentNum, String code, Boolean isRecruit, Long stepNum) {
+    public Roadmap(Long id, User creator, Category category, String name, String description, Boolean isPublic, Long currentNum, String code, Boolean isRecruit, Long stepNum, String image) {
         this.id = id;
         this.creator = creator;
         this.category = category;
@@ -57,6 +59,7 @@ public class Roadmap {
         this.code = code;
         this.isRecruit = isRecruit;
         this.stepNum = stepNum;
+        this.image = image;
     }
 
     public void update(String name, String description, String code, Boolean isPublic, Boolean isRecruit){

--- a/src/main/java/com/example/tily/roadmap/RoadmapController.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapController.java
@@ -53,4 +53,15 @@ public class RoadmapController {
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
+    // 로드맵 조회하기
+    @GetMapping("/roadmaps")
+    public ResponseEntity<?> findRoadmapByQuery(@RequestParam(value="category", defaultValue = "tily") String category,
+                                                @RequestParam(value="name", required = false) String name,
+                                                @RequestParam(value="page", defaultValue = "0") int page,
+                                                @RequestParam(value="size", defaultValue = "9") int size,
+                                                @AuthenticationPrincipal CustomUserDetails userDetails) {
+        RoadmapResponse.FindRoadmapByQueryDTO responseDTO  = roadmapService.findAll(category, name, page, size);
+        return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
+    }
+
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapController.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapController.java
@@ -45,4 +45,12 @@ public class RoadmapController {
 
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
+
+    // 나의 로드맵 전체 목록 조회하기
+    @GetMapping("/roadmaps/my")
+    public ResponseEntity<?> findAllMyRoadmaps(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        RoadmapResponse.FindAllMyRoadmapDTO responseDTO = roadmapService.findAllMyRoadmaps(userDetails.getUser());
+        return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
+    }
+
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapController.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapController.java
@@ -46,7 +46,7 @@ public class RoadmapController {
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
-    // 나의 로드맵 전체 목록 조회하기
+    // 내가 속한 로드맵 전체 목록 조회하기
     @GetMapping("/roadmaps/my")
     public ResponseEntity<?> findAllMyRoadmaps(@AuthenticationPrincipal CustomUserDetails userDetails) {
         RoadmapResponse.FindAllMyRoadmapDTO responseDTO = roadmapService.findAllMyRoadmaps(userDetails.getUser());

--- a/src/main/java/com/example/tily/roadmap/RoadmapRepository.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapRepository.java
@@ -1,7 +1,13 @@
 package com.example.tily.roadmap;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
 
+    @Query("select r from Roadmap r where r.creator.id =:userId and r.category=:category")
+    List<Roadmap> findByUserId(@Param("userId") Long userId, @Param("category") Category category);
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapRepository.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapRepository.java
@@ -1,5 +1,8 @@
 package com.example.tily.roadmap;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,4 +13,7 @@ public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
 
     @Query("select r from Roadmap r where r.creator.id =:userId and r.category=:category")
     List<Roadmap> findByUserId(@Param("userId") Long userId, @Param("category") Category category);
+
+    @Query("select r from Roadmap r where r.category=:category and (:name is null or r.name=:name)")
+    Slice<Roadmap> findAllByOrderByCreatedDateDesc(@Param("category") Category category, @Param("name") String name, Pageable pageable);
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapRepository.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapRepository.java
@@ -14,6 +14,6 @@ public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
     @Query("select r from Roadmap r where r.creator.id =:userId and r.category=:category")
     List<Roadmap> findByUserId(@Param("userId") Long userId, @Param("category") Category category);
 
-    @Query("select r from Roadmap r where r.category=:category and (:name is null or r.name=:name)")
+    @Query("select r from Roadmap r where r.category=:category and (:name is null or r.name=:name) and (r.isPublic=true or r.isPublic is null) and (r.isRecruit=true or r.isRecruit is null)")
     Slice<Roadmap> findAllByOrderByCreatedDateDesc(@Param("category") Category category, @Param("name") String name, Pageable pageable);
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
@@ -6,6 +6,8 @@ import com.example.tily.user.Role;
 import com.example.tily.user.User;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 
 import java.util.List;
 import java.util.Map;
@@ -122,13 +124,13 @@ public class RoadmapResponse {
         }
 
         @Getter @Setter
-        public class RoadmapDTO {
+        public static class RoadmapDTO {
             private List<TilyDTO> tilys;
             private List<GroupDTO> groups;
 
             public RoadmapDTO(List<Roadmap> roadmaps) {
                 this.tilys = roadmaps.stream()
-                        .filter(roadmap -> roadmap.getCategory().equals(Category.CATEGORY_TILLY))
+                        .filter(roadmap -> roadmap.getCategory().equals(Category.CATEGORY_TILY))
                         .map(TilyDTO::new)
                         .collect(Collectors.toList());
                 this.groups = roadmaps.stream()
@@ -151,7 +153,7 @@ public class RoadmapResponse {
             }
 
             @Getter @Setter
-            public class GroupDTO {
+            public static class GroupDTO {
                 private Long id;
                 private String name;
                 private Long stepNum;
@@ -167,7 +169,7 @@ public class RoadmapResponse {
                 }
 
                 @Getter @Setter
-                public class Creator {
+                public static class Creator {
                     private Long id;
                     private String name;
                     private String image;
@@ -178,6 +180,34 @@ public class RoadmapResponse {
                         this.image = user.getImage();
                     }
                 }
+            }
+        }
+    }
+
+    @Getter @Setter
+    public static class FindRoadmapByQueryDTO {
+        private String category;
+        private List<RoadmapDTO> roadmaps;
+        private Boolean hasNext;
+
+        public FindRoadmapByQueryDTO(Category category, Slice<Roadmap> roadmaps) {
+            this.category = category.getValue();
+            this.roadmaps = roadmaps.getContent().stream().map(RoadmapDTO::new).collect(Collectors.toList());
+            this.hasNext = roadmaps.hasNext();
+        }
+
+        @Getter @Setter
+        public class RoadmapDTO {
+            private Long id;
+            private String name;
+            private Long stepNum;
+            private FindAllMyRoadmapDTO.RoadmapDTO.GroupDTO.Creator creator;
+
+            public RoadmapDTO(Roadmap roadmap) {
+                this.id = roadmap.getId();
+                this.name = roadmap.getName();
+                this.stepNum = roadmap.getStepNum();
+                this.creator = new FindAllMyRoadmapDTO.RoadmapDTO.GroupDTO.Creator(roadmap.getCreator());
             }
         }
     }

--- a/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
@@ -96,4 +96,87 @@ public class RoadmapResponse {
             }
         }
     }
+
+    @Getter @Setter
+    public static class FindAllMyRoadmapDTO {
+        private List<CategoryDTO> categories;
+        private RoadmapDTO roadmaps;
+
+        public FindAllMyRoadmapDTO(List<Roadmap> categories, List<Roadmap> roadmaps) {
+            this.categories = categories.stream().map(CategoryDTO::new).collect(Collectors.toList());
+            this.roadmaps = new RoadmapDTO(roadmaps);
+        }
+
+        @Getter @Setter
+        public class CategoryDTO {
+            private Long id;
+            private String name;
+
+            public CategoryDTO(Roadmap roadmap) {
+                this.id = roadmap.getId();
+                this.name = roadmap.getName();
+            }
+        }
+
+        @Getter @Setter
+        public class RoadmapDTO {
+            private List<TilyDTO> tilys;
+            private List<GroupDTO> groups;
+
+            public RoadmapDTO(List<Roadmap> roadmaps) {
+                this.tilys = roadmaps.stream()
+                        .filter(roadmap -> roadmap.getCategory().equals(Category.CATEGORY_TILLY))
+                        .map(TilyDTO::new)
+                        .collect(Collectors.toList());
+                this.groups = roadmaps.stream()
+                        .filter(roadmap -> roadmap.getCategory().equals(Category.CATEGORY_GROUP))
+                        .map(GroupDTO::new)
+                        .collect(Collectors.toList());
+            }
+
+            @Getter @Setter
+            public class TilyDTO {
+                private Long id;
+                private String name;
+                private Long stepNum;
+
+                public TilyDTO(Roadmap roadmap) {
+                    this.id = roadmap.getId();
+                    this.name = roadmap.getName();
+                    this.stepNum = roadmap.getStepNum();
+                }
+            }
+
+            @Getter @Setter
+            public class GroupDTO {
+                private Long id;
+                private String name;
+                private Long stepNum;
+                private String image;
+                private Creator creator;
+
+                public GroupDTO(Roadmap roadmap) {
+                    this.id = roadmap.getId();
+                    this.name = roadmap.getName();
+                    this.stepNum = roadmap.getStepNum();
+                    this.image = roadmap.getImage();
+                    this.creator = new Creator(roadmap.getCreator());
+                }
+
+                @Getter @Setter
+                public class Creator {
+                    private Long id;
+                    private String name;
+                    private String image;
+
+                    public Creator(User user) {
+                        this.id = user.getId();
+                        this.name = user.getName();
+                        this.image = user.getImage();
+                    }
+                }
+            }
+        }
+    }
+
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
@@ -102,8 +102,11 @@ public class RoadmapResponse {
         private List<CategoryDTO> categories;
         private RoadmapDTO roadmaps;
 
-        public FindAllMyRoadmapDTO(List<Roadmap> categories, List<Roadmap> roadmaps) {
-            this.categories = categories.stream().map(CategoryDTO::new).collect(Collectors.toList());
+        public FindAllMyRoadmapDTO(List<Roadmap> roadmaps) {
+            this.categories = roadmaps.stream()
+                    .filter(roadmap -> roadmap.getCategory().equals(Category.CATEGORY_INDIVIDUAL))
+                    .map(CategoryDTO::new)
+                    .collect(Collectors.toList());
             this.roadmaps = new RoadmapDTO(roadmaps);
         }
 

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -25,7 +25,7 @@ public class RoadmapService {
 
     @Transactional
     public RoadmapResponse.CreateRoadmapDTO createIndividualRoadmap(RoadmapRequest.CreateIndividualRoadmapDTO requestDTO, User user){
-        String creator = user.getName();
+        User creator = user;
         Category category = Category.CATEGORY_INDIVIDUAL;
         String name = requestDTO.getName();
         Long stepNum = 0L;
@@ -40,7 +40,7 @@ public class RoadmapService {
     @Transactional
     public RoadmapResponse.CreateRoadmapDTO createGroupRoadmap(RoadmapRequest.CreateGroupRoadmapDTO requestDTO, User user){
         // repository 저장
-        String creator = user.getName();
+        User creator = user;
         Category category = Category.CATEGORY_GROUP;
         String name = requestDTO.getRoadmap().getName();
         String roadmapDescription = requestDTO.getRoadmap().getDescription();

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -1,6 +1,8 @@
 package com.example.tily.roadmap;
 
 import com.example.tily._core.errors.exception.Exception404;
+import com.example.tily.roadmap.relation.UserRoadmap;
+import com.example.tily.roadmap.relation.UserRoadmapRepository;
 import com.example.tily.step.Step;
 import com.example.tily.step.StepRepository;
 import com.example.tily.step.reference.Reference;
@@ -92,6 +94,14 @@ public class RoadmapService {
                 referenceRepository.save(reference);
             }
         }
+
+        UserRoadmap userRoadmap = UserRoadmap.builder()
+                .roadmap(roadmap)
+                .user(user)
+                .role("master")
+                .progress(0)
+                .build();
+        userRoadmapRepository.save(userRoadmap);
 
         return new RoadmapResponse.CreateRoadmapDTO(roadmap);
     }

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -191,4 +191,12 @@ public class RoadmapService {
 
         return sb.toString();
     }
+
+    @Transactional
+    public RoadmapResponse.FindAllMyRoadmapDTO findAllMyRoadmaps(User user) {
+
+        //List<Roadmap> individualRoadmaps = roadmapRepository.findByUserId(user.getId(), Category.CATEGORY_INDIVIDUAL); // 내가 생성한 개인 로드맵 조회
+        List<Roadmap> roadmaps = userRoadmapRepository.findByUserId(user.getId(), true);      // 내가 속한 로드맵 조회
+        return new RoadmapResponse.FindAllMyRoadmapDTO(roadmaps);
+    }
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -22,17 +22,25 @@ public class RoadmapService {
     private final StepRepository stepRepository;
     private final ReferenceRepository referenceRepository;
     private final TilRepository tilRepository;
+    private final UserRoadmapRepository userRoadmapRepository;
 
     @Transactional
     public RoadmapResponse.CreateRoadmapDTO createIndividualRoadmap(RoadmapRequest.CreateIndividualRoadmapDTO requestDTO, User user){
-        User creator = user;
-        Category category = Category.CATEGORY_INDIVIDUAL;
-        String name = requestDTO.getName();
-        Long stepNum = 0L;
 
-        Roadmap roadmap = Roadmap.builder().creator(creator).category(category).name(name).stepNum(stepNum).build();
-
+        Roadmap roadmap = Roadmap.builder()
+                .creator(user)
+                .category(Category.CATEGORY_INDIVIDUAL)
+                .name(requestDTO.getName())
+                .stepNum(0L)
+                .build();
         roadmapRepository.save(roadmap);
+
+        UserRoadmap userRoadmap = UserRoadmap.builder()
+                .roadmap(roadmap)
+                .user(user)
+                .role("master")
+                .build();
+        userRoadmapRepository.save(userRoadmap);
 
         return new RoadmapResponse.CreateRoadmapDTO(roadmap);
     }

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -49,18 +49,18 @@ public class RoadmapService {
 
     @Transactional
     public RoadmapResponse.CreateRoadmapDTO createGroupRoadmap(RoadmapRequest.CreateGroupRoadmapDTO requestDTO, User user){
-        // repository 저장
-        User creator = user;
-        Category category = Category.CATEGORY_GROUP;
-        String name = requestDTO.getRoadmap().getName();
-        String roadmapDescription = requestDTO.getRoadmap().getDescription();
-        Boolean isPublic = requestDTO.getRoadmap().getIsPublic();
-        Long currentNum = 1L; // 현재 인원수는 creator 한 명
-        String code = generateRandomCode();
-        Boolean isRecruit = true; // 그룹 로드맵이기 때문
-        Long stepNum = (long) requestDTO.getSteps().size();
 
-        Roadmap roadmap = Roadmap.builder().creator(creator).category(category).name(name).description(roadmapDescription).isPublic(isPublic).currentNum(currentNum).code(code).isRecruit(isRecruit).stepNum(stepNum).build();
+        Roadmap roadmap = Roadmap.builder()
+                .creator(user)
+                .category(Category.CATEGORY_GROUP)
+                .name(requestDTO.getRoadmap().getName())
+                .description(requestDTO.getRoadmap().getDescription())
+                .isPublic(requestDTO.getRoadmap().getIsPublic())
+                .currentNum(1L)
+                .code(generateRandomCode())
+                .isRecruit(true)
+                .stepNum((long) requestDTO.getSteps().size())
+                .build();
         roadmapRepository.save(roadmap);
 
         List<RoadmapRequest.CreateGroupRoadmapDTO.StepDTO> stepDTOS = requestDTO.getSteps();

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -11,6 +11,7 @@ import com.example.tily.til.Til;
 import com.example.tily.til.TilRepository;
 import com.example.tily.user.User;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -213,8 +214,17 @@ public class RoadmapService {
     @Transactional
     public RoadmapResponse.FindAllMyRoadmapDTO findAllMyRoadmaps(User user) {
 
-        //List<Roadmap> individualRoadmaps = roadmapRepository.findByUserId(user.getId(), Category.CATEGORY_INDIVIDUAL); // 내가 생성한 개인 로드맵 조회
         List<Roadmap> roadmaps = userRoadmapRepository.findByUserId(user.getId(), true);      // 내가 속한 로드맵 조회
         return new RoadmapResponse.FindAllMyRoadmapDTO(roadmaps);
+    }
+
+    @Transactional
+    public RoadmapResponse.FindRoadmapByQueryDTO findAll(String category, String name, int page, int size) {
+
+        // 생성일자를 기준으로 내림차순
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdDate"));
+
+        Slice<Roadmap> roadmaps = roadmapRepository.findAllByOrderByCreatedDateDesc(Category.getCategory(category), name, pageable);
+        return new RoadmapResponse.FindRoadmapByQueryDTO(Category.getCategory(category), roadmaps);
     }
 }

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
@@ -4,6 +4,7 @@ import com.example.tily.roadmap.Roadmap;
 import com.example.tily.user.Role;
 import com.example.tily.user.User;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,9 +20,11 @@ public class UserRoadmap {
     private Long id;
 
     @ManyToOne
+    @JoinColumn(name = "roadmap_id")
     private Roadmap roadmap;
 
     @ManyToOne
+    @JoinColumn(name = "user_id")
     private User user;
 
     @Column
@@ -29,7 +32,17 @@ public class UserRoadmap {
     @Column
     private Boolean isAccept;
     @Column(nullable = false)
-    private Role role;
+    private String role;
     @Column(nullable = false)
     private int progress;
+
+    @Builder
+    public UserRoadmap(Roadmap roadmap, User user, String content, Boolean isAccept, String role, int progress) {
+        this.roadmap = roadmap;
+        this.user = user;
+        this.content = content;
+        this.isAccept = isAccept;
+        this.role = role;
+        this.progress = progress;
+    }
 }

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
@@ -1,5 +1,6 @@
-package com.example.tily.roadmap;
+package com.example.tily.roadmap.relation;
 
+import com.example.tily.roadmap.Roadmap;
 import com.example.tily.user.Role;
 import com.example.tily.user.User;
 import lombok.AccessLevel;
@@ -11,8 +12,8 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name="userRoadmapRelation_tb")
-public class UserRoadmapRelation {
+@Table(name="user_roadmap_tb")
+public class UserRoadmap {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
@@ -19,10 +19,10 @@ public class UserRoadmap {
     private Long id;
 
     @ManyToOne
-    Roadmap roadmap;
+    private Roadmap roadmap;
 
     @ManyToOne
-    User user;
+    private User user;
 
     @Column
     private String content;

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
@@ -23,7 +23,7 @@ public class UserRoadmap {
     @JoinColumn(name = "roadmap_id")
     private Roadmap roadmap;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
@@ -9,5 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface UserRoadmapRepository extends JpaRepository<UserRoadmap, Long> {
-    
+
+    @Query("select ur.roadmap from UserRoadmap ur where ur.user.id=:userId")
+    List<Roadmap> findByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
@@ -1,0 +1,13 @@
+package com.example.tily.roadmap.relation;
+
+import com.example.tily.roadmap.Category;
+import com.example.tily.roadmap.Roadmap;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserRoadmapRepository extends JpaRepository<UserRoadmap, Long> {
+    
+}

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
@@ -5,11 +5,12 @@ import com.example.tily.roadmap.Roadmap;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.core.parameters.P;
 
 import java.util.List;
 
 public interface UserRoadmapRepository extends JpaRepository<UserRoadmap, Long> {
 
-    @Query("select ur.roadmap from UserRoadmap ur where ur.user.id=:userId")
-    List<Roadmap> findByUserId(@Param("userId") Long userId);
+    @Query("select ur.roadmap from UserRoadmap ur where ur.user.id=:userId and (ur.isAccept=:isAccept or ur.isAccept=null)")
+    List<Roadmap> findByUserId(@Param("userId") Long userId, @Param("isAccept") Boolean isAccept);
 }

--- a/src/main/java/com/example/tily/step/Step.java
+++ b/src/main/java/com/example/tily/step/Step.java
@@ -1,6 +1,7 @@
 package com.example.tily.step;
 
 import com.example.tily.roadmap.Roadmap;
+import com.example.tily.step.relation.UserStep;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,7 +23,7 @@ public class Step {
     private Long id;
 
     @OneToMany(mappedBy =  "step")
-    private List<UserStepRelation> userStepRelations = new ArrayList<>();
+    private List<UserStep> userSteps = new ArrayList<>();
 
     @ManyToOne
     private Roadmap roadmap;

--- a/src/main/java/com/example/tily/step/relation/UserStep.java
+++ b/src/main/java/com/example/tily/step/relation/UserStep.java
@@ -1,5 +1,6 @@
-package com.example.tily.step;
+package com.example.tily.step.relation;
 
+import com.example.tily.step.Step;
 import com.example.tily.user.User;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,8 +11,8 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-@Table(name="userStepRelation_tb")
-public class UserStepRelation {
+@Table(name="user_step_tb")
+public class UserStep {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/com/example/tily/user/User.java
+++ b/src/main/java/com/example/tily/user/User.java
@@ -1,7 +1,7 @@
 package com.example.tily.user;
 
 import com.example.tily.BaseTimeEntity;
-import com.example.tily.roadmap.UserRoadmapRelation;
+import com.example.tily.roadmap.relation.UserRoadmap;
 import com.example.tily.step.UserStepRelation;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,7 +23,7 @@ public class User extends BaseTimeEntity {
     private Long id;
 
     @OneToMany(mappedBy =  "user")
-    private List<UserRoadmapRelation> userRoadmapRelations = new ArrayList<>();
+    private List<UserRoadmap> userRoadmaps = new ArrayList<>();
 
     @OneToMany(mappedBy =  "user")
     private List<UserStepRelation> userStepRelations = new ArrayList<>();

--- a/src/main/java/com/example/tily/user/User.java
+++ b/src/main/java/com/example/tily/user/User.java
@@ -2,7 +2,7 @@ package com.example.tily.user;
 
 import com.example.tily.BaseTimeEntity;
 import com.example.tily.roadmap.relation.UserRoadmap;
-import com.example.tily.step.UserStepRelation;
+import com.example.tily.step.relation.UserStep;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,7 +26,7 @@ public class User extends BaseTimeEntity {
     private List<UserRoadmap> userRoadmaps = new ArrayList<>();
 
     @OneToMany(mappedBy =  "user")
-    private List<UserStepRelation> userStepRelations = new ArrayList<>();
+    private List<UserStep> userSteps = new ArrayList<>();
 
     @Column(length = 50, nullable = false, unique = true)
     private String email;

--- a/src/main/java/com/example/tily/user/User.java
+++ b/src/main/java/com/example/tily/user/User.java
@@ -22,8 +22,8 @@ public class User extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy =  "user")
-    private List<UserRoadmap> userRoadmaps = new ArrayList<>();
+//    @OneToMany(mappedBy =  "user")
+//    private List<UserRoadmap> userRoadmaps = new ArrayList<>();
 
     @OneToMany(mappedBy =  "user")
     private List<UserStep> userSteps = new ArrayList<>();

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO user_tb (email, password, name, role) VALUES ('tngus@pusan.ac.kr', '{bcrypt}$2a$10$8H0OT8wgtALJkig6fmypi.Y7jzI5Y7W9PGgRKqnVeS2cLWGifwHF2', 'tngus', 'ROLE_USER');
+--INSERT INTO user_tb (email, password, name, role) VALUES ('tngus@pusan.ac.kr', '{bcrypt}$2a$10$8H0OT8wgtALJkig6fmypi.Y7jzI5Y7W9PGgRKqnVeS2cLWGifwHF2', 'tngus', 'ROLE_USER');
 /*INSERT INTO roadmap_tb (id, name) VALUES ('1', '로드맵 제목')
 INSERT INTO step_tb (id,title) VALUES ('1', '스프링 시큐리티');
 

--- a/src/test/java/com/example/tily/roadmap/RoadmapControllerTest.java
+++ b/src/test/java/com/example/tily/roadmap/RoadmapControllerTest.java
@@ -141,7 +141,7 @@ public class RoadmapControllerTest {
 
         // then
         result.andExpect(jsonPath("$.success").value("true"));
-        result.andExpect(jsonPath("$.result.id").value(6));
+        result.andExpect(jsonPath("$.result.id").value(9));
     }
 
     // 실패 케이스는 화면을 바탕으로 만듦
@@ -217,7 +217,7 @@ public class RoadmapControllerTest {
     @Test
     public void roadmap_group_find_success_test() throws Exception {
         // given
-        Long id = 4L;
+        Long id = 7L;
 
         // when
         ResultActions result = mvc.perform(
@@ -228,10 +228,10 @@ public class RoadmapControllerTest {
         // then
         result.andExpect(jsonPath("$.success").value("true"));
         result.andExpect(jsonPath("$.result.creator.name").value("hong"));
-        result.andExpect(jsonPath("$.result.name").value("JAVA 입문 수업 - 생활 코딩"));
-        result.andExpect(jsonPath("$.result.code").value("pnu1234"));
-        result.andExpect(jsonPath("$.result.steps[0].title").value("다형성(Polymorphism)"));
-        result.andExpect(jsonPath("$.result.steps[0].references.youtube[0].link").value("https://www.youtube.com/watch?v=0L6QWKC1a6k"));
+        result.andExpect(jsonPath("$.result.name").value("JPA 스터디"));
+        result.andExpect(jsonPath("$.result.code").value("ashfkc"));
+        result.andExpect(jsonPath("$.result.steps[0].title").value("스트림(lambda expression)"));
+        result.andExpect(jsonPath("$.result.steps[0].references.youtube[0].link").value("https://www.youtube.com/watch?v=1OLy4Dj_zCg"));
 
         String responseBody = result.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : "+responseBody);

--- a/src/test/java/com/example/tily/roadmap/RoadmapControllerTest.java
+++ b/src/test/java/com/example/tily/roadmap/RoadmapControllerTest.java
@@ -390,4 +390,27 @@ public class RoadmapControllerTest {
         // then
         result.andExpect(jsonPath("$.success").value("false"));
     }
+
+    @DisplayName("내가 속한 로드맵 전체 목록_조회_성공_test")
+    @WithUserDetails(value = "tngus@test.com")
+    @Test
+    public void roadmap_my_find_success_test () throws Exception {
+
+        // given
+
+        // when
+        ResultActions result = mvc.perform(
+                get("/roadmaps/my")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        );
+
+        String responseBody = result.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : "+responseBody);
+
+        // then
+        result.andExpect(jsonPath("$.success").value("true"));
+        result.andExpect(jsonPath("$.result.categories[0].id").value(1L));
+        result.andExpect(jsonPath("$.result.roadmaps.tilys[0].id").value(4L));
+        result.andExpect(jsonPath("$.result.roadmaps.groups[0].id").value(6L));
+    }
 }

--- a/src/test/java/com/example/tily/roadmap/RoadmapControllerTest.java
+++ b/src/test/java/com/example/tily/roadmap/RoadmapControllerTest.java
@@ -14,9 +14,11 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
@@ -141,7 +143,7 @@ public class RoadmapControllerTest {
 
         // then
         result.andExpect(jsonPath("$.success").value("true"));
-        result.andExpect(jsonPath("$.result.id").value(9));
+        result.andExpect(jsonPath("$.result.id").value(15));
     }
 
     // 실패 케이스는 화면을 바탕으로 만듦
@@ -217,7 +219,7 @@ public class RoadmapControllerTest {
     @Test
     public void roadmap_group_find_success_test() throws Exception {
         // given
-        Long id = 7L;
+        Long id = 12L;
 
         // when
         ResultActions result = mvc.perform(
@@ -230,8 +232,8 @@ public class RoadmapControllerTest {
         result.andExpect(jsonPath("$.result.creator.name").value("hong"));
         result.andExpect(jsonPath("$.result.name").value("JPA 스터디"));
         result.andExpect(jsonPath("$.result.code").value("ashfkc"));
-        result.andExpect(jsonPath("$.result.steps[0].title").value("스트림(lambda expression)"));
-        result.andExpect(jsonPath("$.result.steps[0].references.youtube[0].link").value("https://www.youtube.com/watch?v=1OLy4Dj_zCg"));
+        result.andExpect(jsonPath("$.result.steps[0].title").value("다형성(Polymorphism)"));
+        result.andExpect(jsonPath("$.result.steps[0].references.youtube[0].id").value(1L));
 
         String responseBody = result.andReturn().getResponse().getContentAsString();
         System.out.println("테스트 : "+responseBody);
@@ -242,7 +244,7 @@ public class RoadmapControllerTest {
     @Test
     public void roadmap_group_find_fail_test() throws Exception {
         // given
-        Long id = 10L;
+        Long id = 20L;
 
         // when
         ResultActions result = mvc.perform(
@@ -411,6 +413,54 @@ public class RoadmapControllerTest {
         result.andExpect(jsonPath("$.success").value("true"));
         result.andExpect(jsonPath("$.result.categories[0].id").value(1L));
         result.andExpect(jsonPath("$.result.roadmaps.tilys[0].id").value(4L));
-        result.andExpect(jsonPath("$.result.roadmaps.groups[0].id").value(6L));
+        result.andExpect(jsonPath("$.result.roadmaps.groups[0].id").value(13L));
+    }
+
+    @DisplayName("로드맵_조회_성공_test")
+    @WithUserDetails(value = "tngus@test.com")
+    @Test
+    public void roadmap_find_success_test() throws Exception {
+
+        // given
+
+        // when
+        ResultActions result = mvc.perform(
+                get("/roadmaps")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        );
+
+        String responseBody = result.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : "+responseBody);
+
+        // then
+        result.andExpect(jsonPath("$.success").value("true"));
+        result.andExpect(jsonPath("$.result.category").value("tily"));
+        result.andExpect(jsonPath("$.result.roadmaps[0].id").value(9L));
+    }
+
+    @DisplayName("로드맵_조회_파라미터_성공_test")
+    @WithUserDetails(value = "tngus@test.com")
+    @Test
+    public void roadmap_find_paging_success_test() throws Exception {
+
+        // given
+        String category = "group";
+        String name = "JAVA 입문 수업 - 생활 코딩";
+
+        // when
+        ResultActions result = mvc.perform(
+                get("/roadmaps")
+                        .param("category", category)
+                        .param("name", name)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        );
+
+        String responseBody = result.andReturn().getResponse().getContentAsString();
+        System.out.println("테스트 : "+responseBody);
+
+        // then
+        result.andExpect(jsonPath("$.success").value("true"));
+        result.andExpect(jsonPath("$.result.category").value("group"));
+        result.andExpect(jsonPath("$.result.roadmaps[0].name").value("JAVA 입문 수업 - 생활 코딩"));
     }
 }

--- a/src/test/java/com/example/tily/util/DummyEntity.java
+++ b/src/test/java/com/example/tily/util/DummyEntity.java
@@ -2,6 +2,7 @@ package com.example.tily.util;
 
 import com.example.tily.roadmap.Category;
 import com.example.tily.roadmap.Roadmap;
+import com.example.tily.roadmap.relation.UserRoadmap;
 import com.example.tily.step.Step;
 import com.example.tily.til.Til;
 import com.example.tily.user.Role;
@@ -14,17 +15,17 @@ import java.util.Arrays;
 import java.util.List;
 
 public class DummyEntity {
-    protected User newUser(String email, String name){
+    protected User newUser(String email, String name, Role role){
         PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
         return User.builder()
                 .email(email)
                 .name(name)
                 .password(passwordEncoder.encode("hongHong!"))
-                .role(Role.ROLE_USER)
+                .role(role)
                 .build();
     }
 
-    protected Roadmap newIndividualRoadmap(String creator, Category category, String name, Long stepNum){
+    protected Roadmap newIndividualRoadmap(User creator, Category category, String name, Long stepNum){
         return Roadmap.builder()
                 .creator(creator)
                 .category(category)
@@ -33,7 +34,19 @@ public class DummyEntity {
                 .build();
     }
 
-    protected Roadmap newGroupRoadmap(String creator, Category category, String name, String description, boolean isPublic, Long currentNum, String code, boolean isRecruit,Long stepNum){
+    public Roadmap newTilyRoadmap(User creator, Category category, String name, String description, Long currentNum, Long stepNum, String image) {
+        return Roadmap.builder()
+                .creator(creator)
+                .category(category)
+                .name(name)
+                .description(description)
+                .currentNum(currentNum)
+                .stepNum(stepNum)
+                .image(image)
+                .build();
+    }
+
+    protected Roadmap newGroupRoadmap(User creator, Category category, String name, String description, boolean isPublic, Long currentNum, String code, boolean isRecruit,Long stepNum){
         return Roadmap.builder()
                 .creator(creator)
                 .category(category)
@@ -44,6 +57,17 @@ public class DummyEntity {
                 .code(code)
                 .isRecruit(isRecruit)
                 .stepNum(stepNum)
+                .build();
+    }
+
+    private UserRoadmap newUserRoadmapRelation(Roadmap roadmap, User user, String content, Boolean isAccept, String role, int progress) {
+        return UserRoadmap.builder()
+                .roadmap(roadmap)
+                .user(user)
+                .content(content)
+                .isAccept(isAccept)
+                .role(role)
+                .progress(progress)
                 .build();
     }
 
@@ -73,13 +97,42 @@ public class DummyEntity {
                 .commentNum(commentNum)
                 .build();
     }
-    protected List<Roadmap> roadmapDummyList(){
+
+    protected List<User> userDummyList() {
         return Arrays.asList(
-                newIndividualRoadmap("hong",Category.CATEGORY_INDIVIDUAL, "스프링 시큐리티", 10L),
-                newIndividualRoadmap("puuding",Category.CATEGORY_INDIVIDUAL, "JPA 입문", 10L),
-                newIndividualRoadmap("sam-mae",Category.CATEGORY_INDIVIDUAL, "자바 reflection", 10L),
-                newGroupRoadmap("hong", Category.CATEGORY_GROUP, "JAVA 입문 수업 - 생활 코딩", "생활 코딩님의 로드맵입니다!", true, 3L, "pnu1234", true, 3L),
-                newGroupRoadmap("puuding", Category.CATEGORY_GROUP, "JPA 스터디", "김영한 강사님의 JPA를 공부하는 스터디 ^^", false, 10L, "ashfkc", true, 10L)
+                newUser("tngus@test.com", "su", Role.ROLE_USER),
+                newUser("hong@naver.com", "hong", Role.ROLE_USER),
+                newUser("test@test.com", "hongHong", Role.ROLE_USER),
+                newUser("admin@test.com", "admin", Role.ROLE_ADMIN)
+        );
+    }
+    protected List<Roadmap> roadmapDummyList(List<User> userListPS){
+        return Arrays.asList(
+                newIndividualRoadmap(userListPS.get(0), Category.CATEGORY_INDIVIDUAL, "스프링 시큐리티", 10L),
+                newIndividualRoadmap(userListPS.get(1),Category.CATEGORY_INDIVIDUAL, "JPA 입문", 10L),
+                newIndividualRoadmap(userListPS.get(2),Category.CATEGORY_INDIVIDUAL, "자바 reflection", 10L),
+                newTilyRoadmap(userListPS.get(3), Category.CATEGORY_TILLY, "spring boot - 초급편", "틸리에서 제공하는 spring boot 초급자를 위한 로드맵입니다.", 100L, 20L, "image.jpg"),
+                newTilyRoadmap(userListPS.get(3), Category.CATEGORY_TILLY, "spring boot - 중급편", "틸리에서 제공하는 spring boot 중급자를 위한 로드맵입니다.", 80L, 30L , "image.jpg"),
+                newGroupRoadmap(userListPS.get(0), Category.CATEGORY_GROUP, "JAVA 입문 수업 - 생활 코딩", "생활 코딩님의 로드맵입니다!", true, 3L, "pnu1234", true, 3L),
+                newGroupRoadmap(userListPS.get(1), Category.CATEGORY_GROUP, "JPA 스터디", "김영한 강사님의 JPA를 공부하는 스터디 ^^", false, 10L, "ashfkc", true, 10L)
+        );
+    }
+
+    protected List<UserRoadmap> userRoadmapDummyList(List<Roadmap> roadmapListPS, List<User> userListPS) {
+        return Arrays.asList(
+                newUserRoadmapRelation(roadmapListPS.get(0), userListPS.get(0), null, null, "master", 0),
+                newUserRoadmapRelation(roadmapListPS.get(1), userListPS.get(1), null, null, "master", 0),
+                newUserRoadmapRelation(roadmapListPS.get(2), userListPS.get(2), null, null, "master", 0),
+                newUserRoadmapRelation(roadmapListPS.get(3), userListPS.get(3), null, true, "master", 0),
+                newUserRoadmapRelation(roadmapListPS.get(4), userListPS.get(3), null, true, "master", 0),
+                newUserRoadmapRelation(roadmapListPS.get(4), userListPS.get(1), null, true, "member", 20),
+                newUserRoadmapRelation(roadmapListPS.get(4), userListPS.get(2), null, true, "member", 100),
+                newUserRoadmapRelation(roadmapListPS.get(5), userListPS.get(0), null, true, "master", 10),
+                newUserRoadmapRelation(roadmapListPS.get(5), userListPS.get(1), "자바 공부하고싶습니다!", true, "member", 10),
+                newUserRoadmapRelation(roadmapListPS.get(5), userListPS.get(2), "자바 공부하고싶습니다!", true, "member", 10),
+                newUserRoadmapRelation(roadmapListPS.get(6), userListPS.get(1), null, true, "master", 10),
+                newUserRoadmapRelation(roadmapListPS.get(6), userListPS.get(0), "자바 공부하고싶습니다!", true, "member", 0),
+                newUserRoadmapRelation(roadmapListPS.get(6), userListPS.get(2), "자바 공부하고싶습니다!", null, "none", 0)
         );
     }
 
@@ -90,7 +143,8 @@ public class DummyEntity {
                 newIndividualStep(roadmapListPS.get(0), "인증된 사용자 권한 부족 예외처리"),
                 newGroupStep(roadmapListPS.get(3),"다형성(Polymorphism)", "Day1", LocalDateTime.of(2023, 10, 1, 23 ,59) ),
                 newGroupStep(roadmapListPS.get(3),"람다식(lambda expression)", "Day2", LocalDateTime.of(2023, 10, 3, 23 ,59) ),
-                newGroupStep(roadmapListPS.get(4),"스트림(lambda expression)", "Day3", LocalDateTime.of(2023, 10, 5, 23 ,59) )
+                newGroupStep(roadmapListPS.get(6),"스트림(lambda expression)", "Day1", LocalDateTime.of(2023, 10, 5, 23 ,59) ),
+                newGroupStep(roadmapListPS.get(6),"스트림(lambda expression)2", "Day2", LocalDateTime.of(2023, 10, 10, 23 ,59) )
         );
     }
 

--- a/src/test/java/com/example/tily/util/DummyEntity.java
+++ b/src/test/java/com/example/tily/util/DummyEntity.java
@@ -111,8 +111,8 @@ public class DummyEntity {
                 newIndividualRoadmap(userListPS.get(0), Category.CATEGORY_INDIVIDUAL, "스프링 시큐리티", 10L),
                 newIndividualRoadmap(userListPS.get(1),Category.CATEGORY_INDIVIDUAL, "JPA 입문", 10L),
                 newIndividualRoadmap(userListPS.get(2),Category.CATEGORY_INDIVIDUAL, "자바 reflection", 10L),
-                newTilyRoadmap(userListPS.get(3), Category.CATEGORY_TILLY, "spring boot - 초급편", "틸리에서 제공하는 spring boot 초급자를 위한 로드맵입니다.", 100L, 20L, "image.jpg"),
-                newTilyRoadmap(userListPS.get(3), Category.CATEGORY_TILLY, "spring boot - 중급편", "틸리에서 제공하는 spring boot 중급자를 위한 로드맵입니다.", 80L, 30L , "image.jpg"),
+                newTilyRoadmap(userListPS.get(3), Category.CATEGORY_TILY, "spring boot - 초급편", "틸리에서 제공하는 spring boot 초급자를 위한 로드맵입니다.", 100L, 20L, "image.jpg"),
+                newTilyRoadmap(userListPS.get(3), Category.CATEGORY_TILY, "spring boot - 중급편", "틸리에서 제공하는 spring boot 중급자를 위한 로드맵입니다.", 80L, 30L , "image.jpg"),
                 newGroupRoadmap(userListPS.get(0), Category.CATEGORY_GROUP, "JAVA 입문 수업 - 생활 코딩", "생활 코딩님의 로드맵입니다!", true, 3L, "pnu1234", true, 3L),
                 newGroupRoadmap(userListPS.get(1), Category.CATEGORY_GROUP, "JPA 스터디", "김영한 강사님의 JPA를 공부하는 스터디 ^^", false, 10L, "ashfkc", true, 10L)
         );


### PR DESCRIPTION
## 변경사항

메인페이지에서 사용할 내가 속한 로드맵 목록 조회하기 기능과 로드맵 페이지에서 사용할 모집중인 로드맵 목록 조회하기 기능을 구현했습니다. 
또한 UserRoadmap 관계 테이블을 생성하고 가짜 데이터를 많이 추가했습니다. 

## 체크리스트

- [x] 내가 속한 로드맵 목록 조회
- [x] 파라미터로 로드맵 전체 목록 조회
- [x] 테스트 코드 작성
- [x] 코드 리팩토링
- [x] 가짜 데이터 생성

## 논의하고 싶은점

User와 UserRoadmap이 양방향, UserRoadmap과 Roadmap이 양방향으로 설정돼있었는데 불필요한 양방향은 지양하라고 하셔서 일단 단방향으로 수정했습니다! 

또한 개인 로드맵 생성 시 원래는 UserRoadmap 테이블에 저장하지 않았으나, 
내가 속한 로드맵 목록을 조회할 때 UserRoadmap, Roadmap을 각각 조회해야해서 지금은 개인 로드맵 생성할 때도 UserRoadmap 테이블에 저장 (role=master)하고 한 번에 UserRoadmap에서 조회하게 했습니다. 

## Linked Issues

closes #34 
