### PR TITLE
step 목록 조회

### DIFF
--- a/src/main/java/com/example/tily/TiLyApplication.java
+++ b/src/main/java/com/example/tily/TiLyApplication.java
@@ -54,22 +54,22 @@ public class TiLyApplication {
 					newUser("applier@test.com", "applier", passwordEncoder, Role.ROLE_USER)
 			));
 			roadmapRepository.saveAll(Arrays.asList(
-					newIndividualRoadmap(User.builder().id(1L).build(), Category.CATEGORY_INDIVIDUAL, "스프링 시큐리티", 10L), //1
-					newIndividualRoadmap(User.builder().id(2L).build(),Category.CATEGORY_INDIVIDUAL, "JPA 입문", 10L),
-					newIndividualRoadmap(User.builder().id(3L).build(),Category.CATEGORY_INDIVIDUAL, "자바 reflection", 10L),
+					newIndividualRoadmap(User.builder().id(1L).build(), Category.CATEGORY_INDIVIDUAL, "스프링 시큐리티", 10), //1
+					newIndividualRoadmap(User.builder().id(2L).build(),Category.CATEGORY_INDIVIDUAL, "JPA 입문", 10),
+					newIndividualRoadmap(User.builder().id(3L).build(),Category.CATEGORY_INDIVIDUAL, "자바 reflection", 10),
 
-					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "spring boot - 초급편", "틸리에서 제공하는 spring boot 초급자를 위한 로드맵입니다.", 100L, 20L, "image.jpg"), //4
-					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "spring boot - 중급편", "틸리에서 제공하는 spring boot 중급자를 위한 로드맵입니다.", 80L, 30L , "image.jpg"),
-					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "spring boot - 고급편", "틸리에서 제공하는 spring boot 고급자를 위한 로드맵입니다.", 50L, 30L , "image.jpg"),
-					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "Spring JPA - 초급편", "틸리에서 제공하는 Spring JPA 초급자를 위한 로드맵입니다.", 100L, 20L , "image.jpg"),
-					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "Spring JPA - 중급편", "틸리에서 제공하는 Spring JPA 중급자를 위한 로드맵입니다.", 80L, 20L , "image.jpg"),
-					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "Spring JPA - 고급편", "틸리에서 제공하는 Spring JPA 고급자를 위한 로드맵입니다.", 50L, 20L , "image.jpg"),
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "spring boot - 초급편", "틸리에서 제공하는 spring boot 초급자를 위한 로드맵입니다.", 100L, 20, "image.jpg"), //4
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "spring boot - 중급편", "틸리에서 제공하는 spring boot 중급자를 위한 로드맵입니다.", 80L, 30 , "image.jpg"),
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "spring boot - 고급편", "틸리에서 제공하는 spring boot 고급자를 위한 로드맵입니다.", 50L, 30 , "image.jpg"),
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "Spring JPA - 초급편", "틸리에서 제공하는 Spring JPA 초급자를 위한 로드맵입니다.", 100L, 20 , "image.jpg"),
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "Spring JPA - 중급편", "틸리에서 제공하는 Spring JPA 중급자를 위한 로드맵입니다.", 80L, 20 , "image.jpg"),
+					newTilyRoadmap(User.builder().id(4L).build(), Category.CATEGORY_TILY, "Spring JPA - 고급편", "틸리에서 제공하는 Spring JPA 고급자를 위한 로드맵입니다.", 50L, 20 , "image.jpg"),
 
-					newGroupRoadmap(User.builder().id(1L).build(), Category.CATEGORY_GROUP, "JAVA 입문 수업 - 생활 코딩", "생활 코딩님의 로드맵입니다!", true, 5L, "pnu12345", true, 10L), // 10
-					newGroupRoadmap(User.builder().id(1L).build(), Category.CATEGORY_GROUP, "spring boot 스터디", "같이 spring boot 공부해봐요!", true, 3L, "pnu54321", true, 10L),
-					newGroupRoadmap(User.builder().id(2L).build(), Category.CATEGORY_GROUP, "JPA 스터디", "김영한 강사님의 JPA를 공부하는 스터디 ^^", false, 5L, "hoyai123", false, 20L),
-					newGroupRoadmap(User.builder().id(2L).build(), Category.CATEGORY_GROUP, "데이터베이스 스터디", "데이터베이스 공부합시다", true, 8L, "hoyoung1", true, 15L),
-					newGroupRoadmap(User.builder().id(3L).build(), Category.CATEGORY_GROUP, "카카오테크캠퍼스 1단계", "카카오테크캠퍼스 1단계입니다.", false, 50L, "kakao123", true, 20L)
+					newGroupRoadmap(User.builder().id(1L).build(), Category.CATEGORY_GROUP, "JAVA 입문 수업 - 생활 코딩", "생활 코딩님의 로드맵입니다!", true, 5L, "pnu12345", true, 10), // 10
+					newGroupRoadmap(User.builder().id(1L).build(), Category.CATEGORY_GROUP, "spring boot 스터디", "같이 spring boot 공부해봐요!", true, 3L, "pnu54321", true, 10),
+					newGroupRoadmap(User.builder().id(2L).build(), Category.CATEGORY_GROUP, "JPA 스터디", "김영한 강사님의 JPA를 공부하는 스터디 ^^", false, 5L, "hoyai123", false, 20),
+					newGroupRoadmap(User.builder().id(2L).build(), Category.CATEGORY_GROUP, "데이터베이스 스터디", "데이터베이스 공부합시다", true, 8L, "hoyoung1", true, 15),
+					newGroupRoadmap(User.builder().id(3L).build(), Category.CATEGORY_GROUP, "카카오테크캠퍼스 1단계", "카카오테크캠퍼스 1단계입니다.", false, 50L, "kakao123", true, 20)
 
 					));
 			userRoadmapRepository.saveAll(Arrays.asList(
@@ -106,7 +106,11 @@ public class TiLyApplication {
 
 					newGroupStep(Roadmap.builder().id(12L).build(),"다형성(Polymorphism)", "Day1", LocalDateTime.of(2023, 10, 1, 23 ,59) ),
 					newGroupStep(Roadmap.builder().id(12L).build(),"람다식(lambda expression)", "Day2", LocalDateTime.of(2023, 10, 3, 23 ,59) ),
-					newGroupStep(Roadmap.builder().id(12L).build(),"스트림(lambda expression)", "Day3", LocalDateTime.of(2023, 10, 5, 23 ,59) )
+					newGroupStep(Roadmap.builder().id(12L).build(),"스트림(lambda expression)", "Day3", LocalDateTime.of(2023, 10, 5, 23 ,59) ),
+
+					newGroupStep(Roadmap.builder().id(5L).build(),"spring boot 1일차", "Day1", LocalDateTime.of(2023, 10, 1, 23 ,59) ),
+					newGroupStep(Roadmap.builder().id(5L).build(),"spring boot 2일차", "Day2", LocalDateTime.of(2023, 10, 3, 23 ,59) ),
+					newGroupStep(Roadmap.builder().id(5L).build(),"spring boot 3일차", "Day3", LocalDateTime.of(2023, 10, 5, 23 ,59) )
 			));
 			userStepRepository.saveAll(Arrays.asList(
 					newUserStepRelation(Step.builder().id(5L).build(), User.builder().id(1L).build(), true),
@@ -114,6 +118,9 @@ public class TiLyApplication {
 					newUserStepRelation(Step.builder().id(6L).build(), User.builder().id(1L).build(), false),
 					newUserStepRelation(Step.builder().id(6L).build(), User.builder().id(2L).build(), true),
 					newUserStepRelation(Step.builder().id(6L).build(), User.builder().id(5L).build(), true)
+//					newUserStepRelation(Step.builder().id(5L).build(), User.builder().id(1L).build(), false),
+//					newUserStepRelation(Step.builder().id(6L).build(), User.builder().id(1L).build(), false),
+//					newUserStepRelation(Step.builder().id(7L).build(), User.builder().id(1L).build(), false)
 			));
 			referenceRepository.saveAll(Arrays.asList(
 					newReference(Step.builder().id(4L).build(), "youtube", "https://www.youtube.com/watch?v=0L6QWKC1a6k"),
@@ -153,7 +160,7 @@ public class TiLyApplication {
 				.build();
 	}
 
-	private Roadmap newIndividualRoadmap(User creator, Category category, String name, Long stepNum){
+	private Roadmap newIndividualRoadmap(User creator, Category category, String name, int stepNum){
 		return Roadmap.builder()
 				.creator(creator)
 				.category(category)
@@ -162,7 +169,7 @@ public class TiLyApplication {
 				.build();
 	}
 
-	public Roadmap newTilyRoadmap(User creator, Category category, String name, String description, Long currentNum, Long stepNum, String image) {
+	public Roadmap newTilyRoadmap(User creator, Category category, String name, String description, Long currentNum, int stepNum, String image) {
 		return Roadmap.builder()
 				.creator(creator)
 				.category(category)
@@ -174,7 +181,7 @@ public class TiLyApplication {
 				.build();
 	}
 
-	private Roadmap newGroupRoadmap(User creator, Category category, String name, String description, boolean isPublic, Long currentNum, String code, boolean isRecruit,Long stepNum) {
+	private Roadmap newGroupRoadmap(User creator, Category category, String name, String description, boolean isPublic, Long currentNum, String code, boolean isRecruit,int stepNum) {
 		return Roadmap.builder()
 				.creator(creator)
 				.category(category)

--- a/src/main/java/com/example/tily/roadmap/Roadmap.java
+++ b/src/main/java/com/example/tily/roadmap/Roadmap.java
@@ -44,12 +44,12 @@ public class Roadmap extends BaseTimeEntity {
     @Column
     private Boolean isRecruit;
     @Column
-    private Long stepNum;
+    private int stepNum;
     @Column
     private String image;
 
     @Builder
-    public Roadmap(Long id, User creator, Category category, String name, String description, Boolean isPublic, Long currentNum, String code, Boolean isRecruit, Long stepNum, String image) {
+    public Roadmap(Long id, User creator, Category category, String name, String description, Boolean isPublic, Long currentNum, String code, Boolean isRecruit, int stepNum, String image) {
         this.id = id;
         this.creator = creator;
         this.category = category;

--- a/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
@@ -147,7 +147,7 @@ public class RoadmapResponse {
             public class TilyDTO {
                 private Long id;
                 private String name;
-                private Long stepNum;
+                private int stepNum;
 
                 public TilyDTO(Roadmap roadmap) {
                     this.id = roadmap.getId();
@@ -160,7 +160,7 @@ public class RoadmapResponse {
             public static class GroupDTO {
                 private Long id;
                 private String name;
-                private Long stepNum;
+                private int stepNum;
                 private String image;
                 private Creator creator;
 
@@ -204,7 +204,7 @@ public class RoadmapResponse {
         public class RoadmapDTO {
             private Long id;
             private String name;
-            private Long stepNum;
+            private int stepNum;
             private FindAllMyRoadmapDTO.RoadmapDTO.GroupDTO.Creator creator;
 
             public RoadmapDTO(Roadmap roadmap) {

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -40,7 +40,7 @@ public class RoadmapService {
                 .creator(user)
                 .category(Category.CATEGORY_INDIVIDUAL)
                 .name(requestDTO.getName())
-                .stepNum(0L)
+                .stepNum(0)
                 .build();
         roadmapRepository.save(roadmap);
 
@@ -66,7 +66,7 @@ public class RoadmapService {
                 .currentNum(1L)
                 .code(generateRandomCode())
                 .isRecruit(true)
-                .stepNum((long) requestDTO.getSteps().size())
+                .stepNum(requestDTO.getSteps().size())
                 .build();
         roadmapRepository.save(roadmap);
 

--- a/src/main/java/com/example/tily/step/StepController.java
+++ b/src/main/java/com/example/tily/step/StepController.java
@@ -1,8 +1,10 @@
 package com.example.tily.step;
 
+import com.example.tily._core.security.CustomUserDetails;
 import com.example.tily._core.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -25,6 +27,13 @@ public class StepController {
     public ResponseEntity<?> findReference(@PathVariable Long stepsId){
         StepResponse.FindReferenceDTO responseDTO = stepService.findReference(stepsId);
 
+        return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
+    }
+
+    // 특정 로드맵의 step 목록 전체 조회
+    @GetMapping("/roadmaps/{roadmapId}/steps")
+    public ResponseEntity<?> findAllStep(@PathVariable("roadmapId") Long roadmapId, @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        StepResponse.FindAllStepDTO responseDTO = stepService.findAllStep(roadmapId, customUserDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 }

--- a/src/main/java/com/example/tily/step/StepRepository.java
+++ b/src/main/java/com/example/tily/step/StepRepository.java
@@ -3,9 +3,17 @@ package com.example.tily.step;
 import com.example.tily.roadmap.Roadmap;
 import com.example.tily.step.reference.Reference;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StepRepository extends JpaRepository<Step, Long> {
-    List<Step> findByRoadmapId(Long id);
+
+    @Query("select s from Step s join fetch s.roadmap where s.id=:stepId")
+    Optional<Step> findById(@Param("stepId") Long stepId);
+
+    @Query("select s from Step s join fetch s.roadmap where s.roadmap.id=:roadmapId")
+    List<Step> findByRoadmapId(@Param("roadmapId") Long roadmapId);
 }

--- a/src/main/java/com/example/tily/step/StepResponse.java
+++ b/src/main/java/com/example/tily/step/StepResponse.java
@@ -1,9 +1,12 @@
 package com.example.tily.step;
 
+import com.example.tily.til.Til;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class StepResponse {
     @Getter @Setter
@@ -49,6 +52,34 @@ public class StepResponse {
             this.description = step.getDescription();
             this.youtubes = youtubeLinks;
             this.references = referenceLinks;
+        }
+    }
+
+    @Getter @Setter
+    public static class FindAllStepDTO {
+        private List<StepDTO> steps;
+        private int progress;
+        private String role;
+
+        public FindAllStepDTO(List<Step> steps, Map<Step, Til> maps, int progress, String role) {
+            this.steps = steps.stream().map(step -> new StepDTO(step, maps.get(step))).collect(Collectors.toList());
+            this.progress = progress;
+            this.role = role;
+        }
+
+        @Getter @Setter
+        public class StepDTO {
+            private Long id;
+            private String title;
+            private Boolean isCompleted;
+            private Long tillId;
+
+            public StepDTO(Step step, Til til) {
+                this.id = step.getId();
+                this.title = step.getTitle();
+                this.isCompleted = til==null ? false : true;
+                this.tillId = til.getId();
+            }
         }
     }
 }


### PR DESCRIPTION
## 변경사항

특정 roadmap 의 step 목록 조회 기능을 구현했습니다. 
그리고 roadmap안에 step의 개수를 저장하는 stepNum 자료형을 진도율(progress) 계산의 편의성을 위해 long에서 int로 변경했습니다. 

## 체크리스트

-   [x] 특정 roadmap의 step 목록 조회 기능 

## 논의하고 싶은점

step에서 til을 조회할 수 없어서 지금은 hashmap으로 저장해서 dto를 생성했습니다. 만약 DTO 구조나 생성 방법을 변경한다면 이 부분을 더 깔끔하게 구현할 수 있을 것 같습니다

## Linked Issues

closes #54 
