### PR TITLE
Til CRUD 예외 처리 로직 추가 

### DIFF
--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -331,6 +331,14 @@ public class RoadmapService {
                 .orElseThrow(() -> new Exception404("해당 사용자를 찾을 수 없습니다"));
 
         userRoadmap.updateIsAccept(true);
+
+        // 허가하면 수강생이 해당 roadmap에 속한다 -> 제출 여부 관리를 위한 userstep에 다 넣어줘야 함
+        // 로드맵의 모든 step에 대해 userstep에 넣어줘야 한다
+        List<Step> steps = stepRepository.findByRoadmapId(groupsId);
+        for (Step step : steps) {
+            UserStep userStep = UserStep.builder().roadmap(step.getRoadmap()).step(step).user(userRoadmap.getUser()).isSubmit(false).build();
+            userStepRepository.save(userStep);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
@@ -49,4 +49,8 @@ public class UserRoadmap extends BaseTimeEntity {
     public void updateRole(GroupRole role) { this.role = role; }
 
     public void updateIsAccept(Boolean isAccept) { this.isAccept = isAccept; }
+
+    public void updateProgress(int progress) {
+        this.progress = progress;
+    }
 }

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
@@ -21,5 +21,6 @@ public interface UserRoadmapRepository extends JpaRepository<UserRoadmap, Long> 
 
     Optional<UserRoadmap> findByRoadmapIdAndUserIdAndIsAcceptFalse(Long roadmapId, Long userId);
 
-    Optional<UserRoadmap> findByRoadmapIdAndUserId(Long roadmapId, Long userId);
+    @Query("select ur from UserRoadmap ur where ur.roadmap.id=:roadmapId and ur.user.id=:userId")
+    Optional<UserRoadmap> findByRoadmapIdAndUserId(@Param("roadmapId") Long roadmapId,@Param("userId") Long userId);
 }

--- a/src/main/java/com/example/tily/step/StepRepository.java
+++ b/src/main/java/com/example/tily/step/StepRepository.java
@@ -3,9 +3,14 @@ package com.example.tily.step;
 import com.example.tily.roadmap.Roadmap;
 import com.example.tily.step.reference.Reference;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StepRepository extends JpaRepository<Step, Long> {
     List<Step> findByRoadmapId(Long id);
+
+    @Query("select s from Step s join fetch s.roadmap where s.id=:id")
+    Optional<Step> findById(Long id);
 }

--- a/src/main/java/com/example/tily/step/relation/UserStep.java
+++ b/src/main/java/com/example/tily/step/relation/UserStep.java
@@ -1,5 +1,6 @@
 package com.example.tily.step.relation;
 
+import com.example.tily.roadmap.Roadmap;
 import com.example.tily.step.Step;
 import com.example.tily.user.User;
 import lombok.AccessLevel;
@@ -18,19 +19,30 @@ public class UserStep {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
-    Step step;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "roadmap_id")
+    private Roadmap roadmap;
 
-    @ManyToOne
-    User user;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "step_id")
+    private Step step;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @Column(nullable = false)
     private Boolean isSubmit;
 
     @Builder
-    public UserStep(Step step, User user, Boolean isSubmit){
+    public UserStep(Roadmap roadmap, Step step, User user, Boolean isSubmit){
+        this.roadmap = roadmap;
         this.step = step;
         this.user = user;
         this.isSubmit = isSubmit;
+    }
+
+    public void submit() {
+        this.isSubmit = true;
     }
 }

--- a/src/main/java/com/example/tily/step/relation/UserStepRepository.java
+++ b/src/main/java/com/example/tily/step/relation/UserStepRepository.java
@@ -1,10 +1,17 @@
 package com.example.tily.step.relation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserStepRepository extends JpaRepository<UserStep, Long> {
 
     Optional<UserStep> findByUserIdAndStepId(Long userId, Long stepId);
+    List<UserStep> findByUserIdAndRoadmapId(Long userId, Long roadmapId);
+
+    @Query("select us from UserStep us where us.step.id=:stepId")
+    UserStep findByStepId(@Param("stepId") Long stepId);
 }

--- a/src/main/java/com/example/tily/til/TilController.java
+++ b/src/main/java/com/example/tily/til/TilController.java
@@ -16,21 +16,28 @@ public class TilController {
     private final TilService tilService;
 
     @PostMapping("/roadmaps/{roadmapId}/steps/{stepId}/tils")
-    public ResponseEntity<?> createTil(@PathVariable("roadmapId") Long roadmapId, @PathVariable("stepId") Long stepId, @RequestBody @Valid TilRequest.CreateTilDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> createTil(@PathVariable("roadmapId") Long roadmapId,
+                                       @PathVariable("stepId") Long stepId,
+                                       @RequestBody @Valid TilRequest.CreateTilDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
         TilResponse.CreateTilDTO responseDTO = tilService.createTil(requestDTO, roadmapId, stepId, userDetails.getUser());
 
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
     @PatchMapping("/roadmaps/{roadmapId}/steps/{stepId}/tils/{tilId}")
-    public ResponseEntity<?> updateTil(@PathVariable("roadmapId") Long roadmapId, @PathVariable("stepId") Long stepId, @PathVariable("tilId") Long tilId, @RequestBody @Valid TilRequest.UpdateTilDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> updateTil(@PathVariable("roadmapId") Long roadmapId,
+                                       @PathVariable("stepId") Long stepId,
+                                       @PathVariable("tilId") Long tilId,
+                                       @RequestBody @Valid TilRequest.UpdateTilDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
         tilService.updateTil(requestDTO, tilId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
     @GetMapping("/roadmaps/{roadmapId}/steps/{stepId}/tils/{tilId}")
-    public ResponseEntity<?> viewTil(@PathVariable("roadmapId") Long roadmapId, @PathVariable("stepId")Long stepId, @PathVariable("tilId") Long tilId) {
-        TilResponse.ViewDTO responseDTO = tilService.viewTil(tilId, stepId);
+    public ResponseEntity<?> viewTil(@PathVariable("roadmapId") Long roadmapId,
+                                     @PathVariable("stepId")Long stepId,
+                                     @PathVariable("tilId") Long tilId, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        TilResponse.ViewDTO responseDTO = tilService.viewTil(tilId, stepId, userDetails.getUser());
         ApiUtils.ApiResult<?> apiResult= ApiUtils.success(responseDTO);
 
         return ResponseEntity.ok(apiResult);
@@ -47,9 +54,11 @@ public class TilController {
     }
 
     @DeleteMapping("/roadmaps/{roadmapId}/steps/{stepId}/tils/{tilId}")
-    public ResponseEntity<?> deleteTil(@PathVariable("roadmapId") Long roadmapId, @PathVariable("stepId")Long stepId, @PathVariable("tilId") Long tilId) {
+    public ResponseEntity<?> deleteTil(@PathVariable("roadmapId") Long roadmapId,
+                                       @PathVariable("stepId")Long stepId,
+                                       @PathVariable("tilId") Long tilId, @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        tilService.deleteTil(tilId);
+        tilService.deleteTil(tilId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 

--- a/src/main/java/com/example/tily/til/TilController.java
+++ b/src/main/java/com/example/tily/til/TilController.java
@@ -16,15 +16,15 @@ public class TilController {
     private final TilService tilService;
 
     @PostMapping("/roadmaps/{roadmapId}/steps/{stepId}/tils")
-    public ResponseEntity<?> createTil(@PathVariable("roadmapId") Long roadmapId, @PathVariable("stepId") Long stepId, @RequestBody @Valid TilRequest.CreateTilDTO requestDTO) {
-        TilResponse.CreateTilDTO responseDTO = tilService.createTil(requestDTO, roadmapId, stepId);
+    public ResponseEntity<?> createTil(@PathVariable("roadmapId") Long roadmapId, @PathVariable("stepId") Long stepId, @RequestBody @Valid TilRequest.CreateTilDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        TilResponse.CreateTilDTO responseDTO = tilService.createTil(requestDTO, roadmapId, stepId, userDetails.getUser());
 
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
     @PatchMapping("/roadmaps/{roadmapId}/steps/{stepId}/tils/{tilId}")
-    public ResponseEntity<?> updateTil(@PathVariable("roadmapId") Long roadmapId, @PathVariable("stepId") Long stepId, @PathVariable("tilId") Long tilId, @RequestBody @Valid TilRequest.UpdateTilDTO requestDTO) {
-        tilService.updateTil(requestDTO, tilId);
+    public ResponseEntity<?> updateTil(@PathVariable("roadmapId") Long roadmapId, @PathVariable("stepId") Long stepId, @PathVariable("tilId") Long tilId, @RequestBody @Valid TilRequest.UpdateTilDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        tilService.updateTil(requestDTO, tilId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
@@ -42,7 +42,7 @@ public class TilController {
                                        @PathVariable("tilId") Long tilId,
                                        @RequestBody @Valid TilRequest.SubmitTilDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        tilService.submitTil(requestDTO, tilId, userDetails.getUser());
+        tilService.submitTil(requestDTO, roadmapId, stepId, tilId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 

--- a/src/main/java/com/example/tily/til/TilRepository.java
+++ b/src/main/java/com/example/tily/til/TilRepository.java
@@ -40,4 +40,11 @@ public interface TilRepository extends JpaRepository<Til, Long>{
                                                Pageable pageable);
 
     List<Til> findByStep_Id(Long stepId);
+
+    @Query("select t from Til t where t.writer.id=:userId and t.step.id=:stepId")
+    Til findByStepIdAndUserId(@Param("stepId") Long stepId, @Param("userId") Long userId);
+
+    @Query("select t from Til t where t.roadmap.id=:roadmapId")
+    List<Til> findByRoadmapId(@Param("roadmapId") Long roadmapId);
+
 }

--- a/src/main/java/com/example/tily/til/TilRepository.java
+++ b/src/main/java/com/example/tily/til/TilRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +16,8 @@ public interface TilRepository extends JpaRepository<Til, Long>{
     Til findFirstByOrderBySubmitDateDesc();
 
     Til findTilById(Long id);
+
+    @Query("select t from Til t join fetch t.writer where t.id=:id")
     Optional<Til> findById(Long id);
 
     @Query("select t from Til t where t.writer.id=:userId " +

--- a/src/main/java/com/example/tily/til/TilResponse.java
+++ b/src/main/java/com/example/tily/til/TilResponse.java
@@ -60,57 +60,57 @@ public class TilResponse {
 
     }
 
+    @Getter
+    @Setter
+    public static class FindAllDTO {
+        private List<TilDTO> tils;
+        private Boolean hasNext;
+
+        public FindAllDTO(Slice<Til> tils) {
+            this.tils = tils.getContent().stream()
+                    .map(til -> new TilDTO(til, til.getStep(), til.getRoadmap()))
+                    .collect(Collectors.toList());
+            this.hasNext = tils.hasNext();
+        }
+
         @Getter
         @Setter
-        public static class FindAllDTO {
-            private List<TilDTO> tils;
-            private Boolean hasNext;
+        public class TilDTO {
+            private Long id;
+            private String createDate;
+            private StepDTO step;
+            private RoadmapDTO roadmap;
 
-            public FindAllDTO(Slice<Til> tils) {
-                this.tils = tils.getContent().stream()
-                        .map(til -> new TilDTO(til, til.getStep(), til.getRoadmap()))
-                        .collect(Collectors.toList());
-                this.hasNext = tils.hasNext();
+            public TilDTO(Til til, Step step, Roadmap roadmap) {
+                this.id = til.getId();
+                this.createDate = til.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+                this.step = new StepDTO(step);
+                this.roadmap = new RoadmapDTO(roadmap);
             }
 
             @Getter
             @Setter
-            public class TilDTO {
+            public class StepDTO {
                 private Long id;
-                private String createDate;
-                private StepDTO step;
-                private RoadmapDTO roadmap;
+                private String title;
 
-                public TilDTO(Til til, Step step, Roadmap roadmap) {
-                    this.id = til.getId();
-                    this.createDate = til.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-                    this.step = new StepDTO(step);
-                    this.roadmap = new RoadmapDTO(roadmap);
+                public StepDTO(Step step) {
+                    this.id = step.getId();
+                    this.title = step.getTitle();
                 }
+            }
 
-                @Getter
-                @Setter
-                public class StepDTO {
-                    private Long id;
-                    private String title;
+            @Getter
+            @Setter
+            public class RoadmapDTO {
+                private Long id;
+                private String name;
 
-                    public StepDTO(Step step) {
-                        this.id = step.getId();
-                        this.title = step.getTitle();
-                    }
-                }
-
-                @Getter
-                @Setter
-                public class RoadmapDTO {
-                    private Long id;
-                    private String name;
-
-                    public RoadmapDTO(Roadmap roadmap) {
-                        this.id = roadmap.getId();
-                        this.name = roadmap.getName();
-                    }
+                public RoadmapDTO(Roadmap roadmap) {
+                    this.id = roadmap.getId();
+                    this.name = roadmap.getName();
                 }
             }
         }
+    }
 }

--- a/src/main/java/com/example/tily/til/TilService.java
+++ b/src/main/java/com/example/tily/til/TilService.java
@@ -2,12 +2,18 @@ package com.example.tily.til;
 
 import com.example.tily._core.errors.exception.Exception400;
 
+import com.example.tily._core.errors.exception.Exception404;
+import com.example.tily.comment.Comment;
 import com.example.tily.comment.CommentRepository;
 import com.example.tily._core.errors.exception.Exception403;
 import com.example.tily.roadmap.Roadmap;
 import com.example.tily.roadmap.RoadmapRepository;
+import com.example.tily.roadmap.relation.UserRoadmap;
+import com.example.tily.roadmap.relation.UserRoadmapRepository;
 import com.example.tily.step.Step;
 import com.example.tily.step.StepRepository;
+import com.example.tily.step.relation.UserStep;
+import com.example.tily.step.relation.UserStepRepository;
 import com.example.tily.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -22,8 +28,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -36,9 +42,12 @@ public class TilService {
     private final StepRepository stepRepository;
     private final RoadmapRepository roadmapRepository;
     private final CommentRepository commentRepository;
+    private final UserStepRepository userStepRepository;
+    private final UserRoadmapRepository userRoadmapRepository;
 
+    // til 생성하기
     @Transactional
-    public TilResponse.CreateTilDTO createTil(TilRequest.CreateTilDTO requestDTO, Long roadmapId, Long stepId) {
+    public TilResponse.CreateTilDTO createTil(TilRequest.CreateTilDTO requestDTO, Long roadmapId, Long stepId, User user) {
 
         Roadmap roadmap = roadmapRepository.findById(roadmapId).orElseThrow(
                 () -> new Exception400("해당 로드맵을 찾을 수 없습니다")
@@ -48,19 +57,40 @@ public class TilService {
                 () -> new Exception400("해당 스텝을 찾을 수 없습니다")
         );
 
-        String title = step.getTitle();
-        Til til = Til.builder().roadmap(roadmap).step(step).title(title).build();
-        tilRepository.save(til);
+        // 로드맵에 속한 step이 맞는지 확인
+        if (!step.getRoadmap().equals(roadmap)) {
+            throw new Exception400("현재 로드맵에는 해당 step이 존재하지 않습니다.");
+        }
 
-        return new TilResponse.CreateTilDTO(til);
+        // 사용자가 속하지 않은 로드맵에 til을 생성하려고 할때
+        userRoadmapRepository.findByRoadmapIdAndUserIdAndIsAcceptTrue(roadmapId, user.getId()).orElseThrow(
+                () -> new Exception403("해당 로드맵에 til을 생성할 권한이 없습니다.")
+        );
+
+        // 사용자가 이미 step에 대한 til을 생성한 경우
+        Til til = tilRepository.findByStepIdAndUserId(stepId, user.getId());
+        if (til != null) {
+            throw new Exception400("이미 해당 step에 대한 til이 존재합니다.");
+        }
+
+        String title = step.getTitle();
+        Til newTil = Til.builder().roadmap(roadmap).step(step).title(title).writer(user).build();
+        tilRepository.save(newTil);
+
+        return new TilResponse.CreateTilDTO(newTil);
     }
 
+    // til 저장하기
     @Transactional
-    public void updateTil(TilRequest.UpdateTilDTO requestDTO, Long id) {
+    public void updateTil(TilRequest.UpdateTilDTO requestDTO, Long id, User user) {
 
         Til til = tilRepository.findById(id).orElseThrow(
                 () -> new Exception400("해당 til을 찾을 수 없습니다.")
         );
+
+        if (!til.getWriter().getId().equals(user.getId())) {
+            throw new Exception403("해당 til을 저장할 권한이 없습니다.");
+        }
 
         String content = requestDTO.getContent();
         if(content == null){

--- a/src/main/java/com/example/tily/til/TilService.java
+++ b/src/main/java/com/example/tily/til/TilService.java
@@ -99,7 +99,7 @@ public class TilService {
         til.updateContent(content);
     }
 
-    public TilResponse.ViewDTO viewTil(Long tilId, Long stepId) {
+    public TilResponse.ViewDTO viewTil(Long tilId, Long stepId, User user) {
         Til til = tilRepository.findById(tilId).orElseThrow(
                 () -> new Exception400("해당 TIL을 찾을 수 없습니다. ")
         );
@@ -107,17 +107,20 @@ public class TilService {
                 () -> new Exception400("해당 스텝을 찾을 수 없습니다. ")
         );
 
+        List<Comment> comments = commentRepository.findByTilId(tilId);
+
         return new TilResponse.ViewDTO(step, til, comments);
     }
 
-    @Transactional
-    public void submitTil(TilRequest.SubmitTilDTO requestDTO, Long id, User user) {
 
-        Til til = tilRepository.findById(id).orElseThrow(
+    @Transactional
+    public void submitTil(TilRequest.SubmitTilDTO requestDTO, Long roadmapId, Long stepId, Long tilId, User user) {
+
+        Til til = tilRepository.findById(tilId).orElseThrow(
                 () -> new Exception400("해당 til을 찾을 수 없습니다.")
         );
 
-        if (til.getWriter().getId() != user.getId()) {
+        if (!Objects.equals(til.getWriter().getId(), user.getId())) {
             throw new Exception403("til을 제출할 권한이 없습니다.");
         }
 
@@ -125,17 +128,35 @@ public class TilService {
         if(submitContent == null){
             throw new Exception400("TIL 내용을 입력해주세요.");
         }
+
         // 제출 내용을 저장 내용에도 저장
         til.submitTil(submitContent);
+
+        // 제출 여부(완료) 저장
+        UserStep userstep = userStepRepository.findByStepId(stepId);
+        if (userstep.getIsSubmit().equals(true)) {
+            throw new Exception400("이미 한번 제출하였습니다.");
+        }
+        userstep.submit();
+
+        UserRoadmap userRoadmap = userRoadmapRepository.findByRoadmapIdAndUserId(roadmapId, user.getId()).orElseThrow(
+                () -> new Exception403("해당 로드맵에 속하지 않았습니다.")
+        );
+        int progress = calProgress(roadmapId, user.getId());
+
+        userRoadmap.updateProgress(progress);
     }
 
     @Transactional
-    public void deleteTil(Long id) {
-        Optional<Til> til = tilRepository.findById(id);
+    public void deleteTil(Long id, User user) {
+        Til til = tilRepository.findById(id).orElseThrow(
+                () -> new Exception404("존재하지 않는 til입니다.")
+        );
 
-        if(til.isPresent()) {
-            tilRepository.deleteById(id);
+        if (!til.getWriter().equals(user)) {
+            throw new Exception403("해당 til을 삭제할 권한이 없습니다.");
         }
+        tilRepository.deleteById(id);
     }
 
     @Transactional
@@ -158,5 +179,16 @@ public class TilService {
             Slice<Til> tils = tilRepository.findAllByOrderByCreatedDateDesc(user.getId(), roadmapId, title, pageable);
             return new TilResponse.FindAllDTO(tils);
         }
+    }
+
+    public int calProgress(Long roadmapId, Long userId) {
+
+        List<UserStep> userSteps = userStepRepository.findByUserIdAndRoadmapId(userId, roadmapId);
+        int sumNum = userSteps.size();
+        int submitNum = 0;
+        for (UserStep userStep : userSteps) {
+            if (userStep.getIsSubmit())  submitNum++;
+        }
+        return (int)(((double)submitNum/(double)sumNum)*100.0);
     }
 }


### PR DESCRIPTION
## 변경사항

til 생성, 저장, 제출, 삭제에 대해 권한 처리, 예외 처리를 하는 로직들을 추가했습니다. 
제출은 한번만 가능한 로직, 제출하면 저장 내용에도 제출 내용이 저장되는 로직, step에 대해 하나의 til만 생성가능한 로직 등을 추가했습니다. 
아직 리팩토링은 진행하지 않았습니다. 

또한 user_step 관계 테이블에 roadmap을 추가했습니다. 진도율을 계산할 때 해당 로드맵에 속한 step들의 제출 여부를 알아야해서 조회 기준이 되는 roadmap을 추가햇습니다. 

사용자가 관리자의 허가를 받아 로드맵에 속하면, 
user_step 테이블에 모든 step에 대해 제출 여부(false)로 추가했습니다. 

til을 제출할 때마다 진도율이 달라지므로 user_step에 제출 여부를 업데이트하고 진도율을 계산했습니다.

## 체크리스트

- [ ] Til 생성 시 예외 처리 로직 추가
- [ ] Til 제출 시 예외 처리 로직 추가
- [ ] Til 저장 시 예외 처리 로직 추가
- [ ] 진도율 계산 기능 추가 

## 논의하고 싶은점

## Linked Issues

closes #56 