### PR TITLE
refresh 토큰 적용

### DIFF
--- a/src/main/java/com/example/tily/_core/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/tily/_core/security/JwtAuthenticationFilter.java
@@ -52,7 +52,7 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
         } catch (SignatureVerificationException sve) {
             log.error("토큰 검증 실패");
         } catch (TokenExpiredException tee) {
-            log.error("토큰 만료됨");
+            log.error("access 토큰 만료됨");
         } finally {
             chain.doFilter(request, response);
         }

--- a/src/main/java/com/example/tily/_core/utils/RedisUtils.java
+++ b/src/main/java/com/example/tily/_core/utils/RedisUtils.java
@@ -1,5 +1,6 @@
 package com.example.tily._core.utils;
 
+import com.example.tily.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -13,6 +14,7 @@ import java.time.Duration;
 public class RedisUtils {
 
     private final StringRedisTemplate stringRedisTemplate;
+    public static final Long REFRESH_EXP = 1000L * 60 * 60 * 24 * 7; // 일주일
 
     public String getData(String key) {
         ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
@@ -32,4 +34,5 @@ public class RedisUtils {
     public void deleteData(String key) {
         stringRedisTemplate.delete(key);
     }
+
 }

--- a/src/main/java/com/example/tily/user/UserController.java
+++ b/src/main/java/com/example/tily/user/UserController.java
@@ -48,8 +48,12 @@ public class UserController {
     // 로그인
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody UserRequest.LoginDTO requestDTO, Errors errors) {
-        String jwt = userService.login(requestDTO);
-        return ResponseEntity.ok().header(JWTProvider.HEADER, jwt).body(ApiUtils.success(null));
+        UserResponse.TokenDTO responseDTO = userService.login(requestDTO);
+        ResponseCookie responseCookie = setRefreshTokenCookie(responseDTO.getRefreshToken());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(ApiUtils.success(new UserResponse.LoginDTO(responseDTO.getAccessToken())));
     }
 
     // 비밀번호 재설정

--- a/src/main/java/com/example/tily/user/UserController.java
+++ b/src/main/java/com/example/tily/user/UserController.java
@@ -77,4 +77,13 @@ public class UserController {
                 .body(ApiUtils.success(new UserResponse.LoginDTO(responseDTO.getAccessToken())));
     }
 
+    public ResponseCookie setRefreshTokenCookie(String refreshToken) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("None")
+                .maxAge(JWTProvider.REFRESH_EXP)
+                .build();
+    }
+
 }

--- a/src/main/java/com/example/tily/user/UserController.java
+++ b/src/main/java/com/example/tily/user/UserController.java
@@ -3,9 +3,13 @@ package com.example.tily.user;
 import com.example.tily._core.security.JWTProvider;
 import com.example.tily._core.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -61,6 +65,16 @@ public class UserController {
     public ResponseEntity<?> changePassword(@RequestBody @Valid UserRequest.ChangePwdDTO requestDTO, Errors errors) {
         userService.changePassword(requestDTO);
         return ResponseEntity.ok().body(ApiUtils.success(null));
+    }
+
+    @GetMapping("/refresh")
+    public ResponseEntity<?> refresh(@CookieValue String refreshToken) {
+        UserResponse.TokenDTO responseDTO = userService.refresh(refreshToken);
+        ResponseCookie responseCookie = setRefreshTokenCookie(responseDTO.getRefreshToken());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(ApiUtils.success(new UserResponse.LoginDTO(responseDTO.getAccessToken())));
     }
 
 }

--- a/src/main/java/com/example/tily/user/UserResponse.java
+++ b/src/main/java/com/example/tily/user/UserResponse.java
@@ -13,4 +13,22 @@ public class UserResponse {
             this.email = email;
         }
     }
+
+    @Getter @Setter
+    public static class LoginDTO {
+        private String accessToken;
+        public LoginDTO(String accessToken) {
+            this.accessToken = accessToken;
+        }
+    }
+
+    @Getter @Setter
+    public static class TokenDTO {
+        private String accessToken;
+        private String refreshToken;
+        public TokenDTO(String accessToken, String refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+    }
 }

--- a/src/main/java/com/example/tily/user/UserService.java
+++ b/src/main/java/com/example/tily/user/UserService.java
@@ -87,7 +87,7 @@ public class UserService {
     }
 
     @Transactional
-    public String login(UserRequest.LoginDTO requestDTO) {
+    public UserResponse.TokenDTO login(UserRequest.LoginDTO requestDTO) {
         User user = userRepository.findByEmail(requestDTO.getEmail()).orElseThrow(
                 () -> new Exception404("해당 이메일을 찾을 수 없습니다 : "+requestDTO.getEmail())
         );
@@ -97,6 +97,7 @@ public class UserService {
         }
 
         return JWTProvider.create(user);
+        return createToken(user);
     }
 
     @Transactional

--- a/src/main/java/com/example/tily/user/UserService.java
+++ b/src/main/java/com/example/tily/user/UserService.java
@@ -155,4 +155,14 @@ public class UserService {
         return content;
     }
 
+    public UserResponse.TokenDTO createToken(User user) {
+
+        String newRefreshToken = JWTProvider.createRefreshToken(user);
+        String newAccessToken = JWTProvider.createAccessToken(user);
+        redisUtils.deleteData(user.getId().toString());
+        redisUtils.setDataExpire(user.getId().toString(), newRefreshToken, JWTProvider.REFRESH_EXP);
+
+        return new UserResponse.TokenDTO(newAccessToken, newRefreshToken);
+    }
+
 }


### PR DESCRIPTION
## 변경사항

access token과 refresh token을 적용했습니다. 
token은 redis에서 관리하며, redis에는 refresh token만 저장하고 있습니다. 
현재는 header에 access token을 넣고, cookie에 refresh 토큰을 관리하고 있습니다. (각각 유효기간은 1시간, 일주일) refresh api를 통해 refresh 토큰의 유효성 검사 후 access token과 refresh token을 재발급 받습니다. 

## 체크리스트

- [x] 로그인 시 access token, refresh token 생성
- [x] refresh 시 access token, refresh token 재발급
- [x] redis에서 token 저장

## 논의하고 싶은점

현재는 refresh api에서 cookie를 통해 refresh token을 받아 재발급을 하고 있습니다. 하지만 보안상 좋지 않은 것 같아, filter에서 처리해야 할 것 같아 고민입니다.  

## Linked Issues

closes #70 
