### PR TITLE
TIL 관련 리팩토링

### DIFF
--- a/src/main/java/com/example/tily/TiLyApplication.java
+++ b/src/main/java/com/example/tily/TiLyApplication.java
@@ -75,9 +75,9 @@ public class TiLyApplication {
 
 					));
 			userRoadmapRepository.saveAll(Arrays.asList(
-					newUserRoadmapRelation(Roadmap.builder().id(1L).build(), User.builder().id(1L).build(), null, null, GroupRole.ROLE_MASTER, 0),
-					newUserRoadmapRelation(Roadmap.builder().id(2L).build(), User.builder().id(2L).build(), null, null, GroupRole.ROLE_MASTER, 0),
-					newUserRoadmapRelation(Roadmap.builder().id(3L).build(), User.builder().id(3L).build(), null, null, GroupRole.ROLE_MASTER, 0),
+					newUserRoadmapRelation(Roadmap.builder().id(1L).build(), User.builder().id(1L).build(), null, true, GroupRole.ROLE_MASTER, 0),
+					newUserRoadmapRelation(Roadmap.builder().id(2L).build(), User.builder().id(2L).build(), null, true, GroupRole.ROLE_MASTER, 0),
+					newUserRoadmapRelation(Roadmap.builder().id(3L).build(), User.builder().id(3L).build(), null, true, GroupRole.ROLE_MASTER, 0),
 
 					newUserRoadmapRelation(Roadmap.builder().id(4L).build(), User.builder().id(4L).build(), null, true, GroupRole.ROLE_MASTER, 10),
 					newUserRoadmapRelation(Roadmap.builder().id(4L).build(), User.builder().id(1L).build(), null, true, GroupRole.ROLE_MEMBER, 10),
@@ -161,7 +161,7 @@ public class TiLyApplication {
 		return User.builder()
 				.email(email)
 				.name(name)
-				.password(passwordEncoder.encode("hongHong!"))
+				.password(passwordEncoder.encode("hongHong1!"))
 				.role(role)
 				.build();
 	}

--- a/src/main/java/com/example/tily/_core/errors/GlobalValidationHandler.java
+++ b/src/main/java/com/example/tily/_core/errors/GlobalValidationHandler.java
@@ -1,6 +1,8 @@
 package com.example.tily._core.errors;
 
+import com.example.tily._core.errors.exception.CustomException;
 import com.example.tily._core.errors.exception.Exception400;
+import com.example.tily._core.errors.exception.ExceptionCode;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -15,7 +17,11 @@ public class GlobalValidationHandler {
     public void postMapping() {
     }
 
-    @Before("postMapping()")
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PatchMapping)")
+    public void patchMapping() {
+    }
+
+    @Before("postMapping() || patchMapping()")
     public void validationAdvice(JoinPoint jp) {
         Object[] args = jp.getArgs();
         for (Object arg : args) {
@@ -23,9 +29,7 @@ public class GlobalValidationHandler {
                 Errors errors = (Errors) arg;
 
                 if (errors.hasErrors()) {
-                    throw new Exception400(
-                            errors.getFieldErrors().get(0).getDefaultMessage()
-                    );
+                    throw new CustomException(ExceptionCode.BAD_REQUEST, errors.getFieldErrors().get(0).getDefaultMessage());
                 }
             }
         }

--- a/src/main/java/com/example/tily/_core/errors/exception/CustomException.java
+++ b/src/main/java/com/example/tily/_core/errors/exception/CustomException.java
@@ -15,6 +15,11 @@ public class CustomException extends RuntimeException {
         this.message = exceptionCode.getMessage();
     }
 
+    public CustomException(ExceptionCode exceptionCode, String message) {
+        this.exceptionCode = exceptionCode;
+        this.message = message;
+    }
+
     public ApiUtils.ApiResult<?> body(){
         return ApiUtils.error(message, exceptionCode.getHttpStatus());
     }

--- a/src/main/java/com/example/tily/_core/errors/exception/ExceptionCode.java
+++ b/src/main/java/com/example/tily/_core/errors/exception/ExceptionCode.java
@@ -36,10 +36,12 @@ public enum ExceptionCode {
     ROADMAP_NOT_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 로드냅에 속하지 않았습니다."),
     ROADMAP_NOT_BELONG(HttpStatus.NOT_FOUND, "해당 reoadmap에 속하지 않습니다."),
     ROADMAP_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 roadmap을 조회할 권한이 없습니다."),
+    ROADMAP_SUBMIT_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 til을 제출할 권한이 없습니다."),
 
     // step 관련 에러
     STEP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 step을 찾을 수 없습니다."),
     STEP_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 step을 조회할 권한이 없습니다."),
+    STEP_NOT_INCLUDE(HttpStatus.BAD_REQUEST, "해당 step은 roadmap에 속하지 않았습니다."),
 
     // comment 관련 에러
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글을 찾을 수 없습니다."),
@@ -52,8 +54,9 @@ public enum ExceptionCode {
     DATE_WRONG(HttpStatus.BAD_REQUEST, "입력한 날짜를 찾을 수 없습니다."),
 
     // reference 관련 에러
-    REFERENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 reference를 찾을 수 없습니다.");
+    REFERENCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 reference를 찾을 수 없습니다."),
 
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "올바른 형식을 입력해주세요.");
     private final HttpStatus httpStatus;
     private final String message;
 }

--- a/src/main/java/com/example/tily/comment/CommentRepository.java
+++ b/src/main/java/com/example/tily/comment/CommentRepository.java
@@ -1,12 +1,13 @@
 package com.example.tily.comment;
 
-import com.example.tily.til.TilResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    @Query("select c from Comment c join fetch c.writer where c.til.id=:tilId")
     List<Comment> findByTilId(@Param("tilId") Long tilId);
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -52,6 +52,7 @@ public class RoadmapService {
                 .roadmap(roadmap)
                 .user(user)
                 .role(GroupRole.ROLE_MASTER)
+                .isAccept(true)
                 .build();
         userRoadmapRepository.save(userRoadmap);
 
@@ -85,6 +86,9 @@ public class RoadmapService {
             Step step = Step.builder().roadmap(roadmap).title(title).description(stepDescription).dueDate(dueDate).build();
             stepRepository.save(step);
 
+            UserStep userStep = UserStep.builder().roadmap(roadmap).step(step).user(user).isSubmit(false).build();
+            userStepRepository.save(userStep);
+
             // reference 저장
             RoadmapRequest.ReferenceDTOs referenceDTOs = stepDTO.references();
             List<Reference> referenceList = new ArrayList<>();
@@ -115,6 +119,7 @@ public class RoadmapService {
                 .user(user)
                 .role(GroupRole.ROLE_MASTER)
                 .progress(0)
+                .isAccept(true)
                 .build();
         userRoadmapRepository.save(userRoadmap);
 

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
@@ -27,7 +27,7 @@ public class UserRoadmap extends BaseTimeEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @Column
+    @Column(columnDefinition="TEXT", length = 1000)
     private String content;
     @Column
     private Boolean isAccept;

--- a/src/main/java/com/example/tily/step/StepController.java
+++ b/src/main/java/com/example/tily/step/StepController.java
@@ -23,7 +23,7 @@ public class StepController {
     }
 
     // 특정 step의 참고자료 목록 조회
-    @PostMapping("/roadmaps/{roadmapsId}/steps/{stepsId}/references")
+    @GetMapping("/roadmaps/{roadmapsId}/steps/{stepsId}/references")
     public ResponseEntity<?> findReference(@PathVariable Long stepsId){
         StepResponse.FindReferenceDTO responseDTO = stepService.findReference(stepsId);
 

--- a/src/main/java/com/example/tily/step/StepController.java
+++ b/src/main/java/com/example/tily/step/StepController.java
@@ -16,8 +16,8 @@ public class StepController {
 
     // 개인 로드맵(카테고리)의 step 생성하기
     @PostMapping("/roadmaps/individual/{id}/steps")
-    public ResponseEntity<?> createIndividualStep(@PathVariable Long id, @RequestBody @Valid StepRequest.CreateIndividualStepDTO requestDTO) {
-        StepResponse.CreateIndividualStepDTO responseDTO = stepService.createIndividualStep(id, requestDTO);
+    public ResponseEntity<?> createIndividualStep(@PathVariable Long id, @RequestBody @Valid StepRequest.CreateIndividualStepDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        StepResponse.CreateIndividualStepDTO responseDTO = stepService.createIndividualStep(id, requestDTO, userDetails.getUser());
 
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }

--- a/src/main/java/com/example/tily/step/StepResponse.java
+++ b/src/main/java/com/example/tily/step/StepResponse.java
@@ -22,9 +22,9 @@ public class StepResponse {
     }
 
     public record FindAllStepDTO(List<StepDTO> steps, int progress, String role) {
-        public record StepDTO(Long id, String title, Boolean isCompleted, Long tillId) {
+        public record StepDTO(Long id, String title, Boolean isSubmit, Long tilId) {
             public StepDTO(Step step, Til til) {
-                this(step.getId(), step.getTitle(), til == null ? false : true, til.getId());
+                this(step.getId(), step.getTitle(), til != null, til==null ? null : til.getId());
             }
         }
     }

--- a/src/main/java/com/example/tily/step/StepService.java
+++ b/src/main/java/com/example/tily/step/StepService.java
@@ -8,6 +8,7 @@ import com.example.tily.roadmap.relation.UserRoadmap;
 import com.example.tily.roadmap.relation.UserRoadmapRepository;
 import com.example.tily.step.reference.Reference;
 import com.example.tily.step.reference.ReferenceRepository;
+import com.example.tily.step.relation.UserStep;
 import com.example.tily.step.relation.UserStepRepository;
 import com.example.tily.til.Til;
 import com.example.tily.til.TilRepository;
@@ -31,15 +32,19 @@ public class StepService {
     private final ReferenceRepository referenceRepository;
     private final TilRepository tilRepository;
     private final UserRoadmapRepository userRoadmapRepository;
+    private final UserStepRepository userStepRepository;
 
     @Transactional
-    public StepResponse.CreateIndividualStepDTO createIndividualStep(Long id, StepRequest.CreateIndividualStepDTO requestDTO){
+    public StepResponse.CreateIndividualStepDTO createIndividualStep(Long id, StepRequest.CreateIndividualStepDTO requestDTO, User user){
         Roadmap roadmap = roadmapRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ExceptionCode.ROADMAP_NOT_FOUND));
         String title = requestDTO.title();
 
         Step step = Step.builder().roadmap(roadmap).title(title).build();
         stepRepository.save(step);
+
+        UserStep userStep = UserStep.builder().roadmap(roadmap).step(step).user(user).isSubmit(true).build();
+        userStepRepository.save(userStep);
 
         return new StepResponse.CreateIndividualStepDTO(step);
     }

--- a/src/main/java/com/example/tily/step/StepService.java
+++ b/src/main/java/com/example/tily/step/StepService.java
@@ -68,7 +68,7 @@ public class StepService {
                 StepResponse.FindReferenceDTO.YoutubeDTO youtubeDTO = new StepResponse.FindReferenceDTO.YoutubeDTO(id, link);
                 youtubeDTOs.add(youtubeDTO);
             }
-            else if(category.equals("reference") ) {
+            else if(category.equals("web") ) {
                 StepResponse.FindReferenceDTO.WebDTO webDTO = new StepResponse.FindReferenceDTO.WebDTO(id, link);
                 webDTOS.add(webDTO);
             }

--- a/src/main/java/com/example/tily/step/reference/Reference.java
+++ b/src/main/java/com/example/tily/step/reference/Reference.java
@@ -23,7 +23,8 @@ public class Reference {
 
     @Column(nullable = false)
     private String category;
-    @Column(nullable = false)
+
+    @Column(nullable = false, columnDefinition="TEXT", length = 1000)
     private String link;
 
     @Builder

--- a/src/main/java/com/example/tily/til/TilController.java
+++ b/src/main/java/com/example/tily/til/TilController.java
@@ -5,6 +5,7 @@ import com.example.tily._core.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -18,11 +19,10 @@ public class TilController {
     @PostMapping("/roadmaps/{roadmapId}/steps/{stepId}/tils")
     public ResponseEntity<?> createTil(@PathVariable("roadmapId") Long roadmapId,
                                        @PathVariable("stepId") Long stepId,
-                                       @RequestBody @Valid TilRequest.CreateTilDTO requestDTO,
+                                       @RequestBody @Valid TilRequest.CreateTilDTO requestDTO,  Errors errors,
                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         TilResponse.CreateTilDTO responseDTO = tilService.createTil(requestDTO, roadmapId, stepId, userDetails.getUser());
-
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
@@ -30,11 +30,10 @@ public class TilController {
     public ResponseEntity<?> updateTil(@PathVariable("roadmapId") Long roadmapId,
                                        @PathVariable("stepId") Long stepId,
                                        @PathVariable("tilId") Long tilId,
-                                       @RequestBody @Valid TilRequest.UpdateTilDTO requestDTO,
+                                       @RequestBody @Valid TilRequest.UpdateTilDTO requestDTO, Errors errors,
                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         tilService.updateTil(requestDTO, tilId, userDetails.getUser());
-
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
@@ -44,17 +43,15 @@ public class TilController {
                                      @PathVariable("tilId") Long tilId,
                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        TilResponse.ViewDTO responseDTO = tilService.viewTil(tilId, stepId, userDetails.getUser());
-        ApiUtils.ApiResult<?> apiResult= ApiUtils.success(responseDTO);
-
-        return ResponseEntity.ok(apiResult);
+        TilResponse.ViewDTO responseDTO = tilService.viewTil(roadmapId, stepId, tilId, userDetails.getUser());
+        return ResponseEntity.ok(ApiUtils.success(responseDTO));
     }
 
     @PostMapping("/roadmaps/{roadmapId}/steps/{stepId}/tils/{tilId}")
     public ResponseEntity<?> submitTil(@PathVariable("roadmapId") Long roadmapId,
                                        @PathVariable("stepId")Long stepId,
                                        @PathVariable("tilId") Long tilId,
-                                       @RequestBody @Valid TilRequest.SubmitTilDTO requestDTO,
+                                       @RequestBody @Valid TilRequest.SubmitTilDTO requestDTO,  Errors errors,
                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         tilService.submitTil(requestDTO, roadmapId, stepId, tilId, userDetails.getUser());
@@ -81,8 +78,6 @@ public class TilController {
                                           @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         TilResponse.FindAllDTO responseDTO = tilService.findAllMyTil(roadmapId, date, title, page, size, userDetails.getUser());
-
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
-
 }

--- a/src/main/java/com/example/tily/til/TilResponse.java
+++ b/src/main/java/com/example/tily/til/TilResponse.java
@@ -22,9 +22,9 @@ public class TilResponse {
         }
     }
 
-    public record ViewDTO(String content, Boolean isPersonal, Boolean isCompleted, StepDTO step, List<CommentDTO> comments) {
-        public ViewDTO(Step step, Til til, Boolean isCompleted, List<CommentDTO> comments) {
-            this(til.getContent(), til.isPersonal(), isCompleted, new StepDTO(step), comments);
+    public record ViewDTO(String content, Boolean isPersonal, Boolean isSubmit, StepDTO step, List<CommentDTO> comments) {
+        public ViewDTO(Step step, Til til, Boolean isSubmit, List<CommentDTO> comments) {
+            this(til.getContent(), til.isPersonal(), isSubmit, new StepDTO(step), comments);
         }
 
         public record StepDTO(Long id, String title) {

--- a/src/main/java/com/example/tily/til/TilService.java
+++ b/src/main/java/com/example/tily/til/TilService.java
@@ -136,16 +136,15 @@ public class TilService {
     }
 
     @Transactional
-    public void deleteTil(Long id, User user) {
-        Til til = getTilById(id);
+    public void deleteTil(Long tilId, User user) {
+        Til til = getTilById(tilId);
 
         if (checkTilWriterEqualUser(til, user))
             throw new CustomException(ExceptionCode.TIL_DELETE_FORBIDDEN);
 
-        tilRepository.deleteById(id);
+        tilRepository.deleteById(tilId);
     }
 
-    @Transactional
     public TilResponse.FindAllDTO findAllMyTil(Long roadmapId, String date, String title, int page, int size, User user) {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdDate"));
@@ -174,12 +173,12 @@ public class TilService {
         return stepRepository.findById(stepId).orElseThrow(() -> new CustomException(ExceptionCode.STEP_NOT_FOUND));
     }
 
-    private boolean checkTilWriterEqualUser(Til til, User user) {
-        return !til.getWriter().getId().equals(user.getId());
-    }
-
     private Til getTilById(Long tilId) {
         return tilRepository.findById(tilId).orElseThrow(() -> new CustomException(ExceptionCode.TIL_NOT_FOUND));
+    }
+
+    private boolean checkTilWriterEqualUser(Til til, User user) {
+        return !til.getWriter().getId().equals(user.getId());
     }
 
     // 사용자가 로드맵에 속했는지

--- a/src/main/java/com/example/tily/user/UserController.java
+++ b/src/main/java/com/example/tily/user/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
 
     // 로그인
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody UserRequest.LoginDTO requestDTO, Errors errors) {
+    public ResponseEntity<?> login(@RequestBody @Valid UserRequest.LoginDTO requestDTO, Errors errors) {
         UserResponse.TokenDTO responseDTO = userService.login(requestDTO);
         ResponseCookie responseCookie = setRefreshTokenCookie(responseDTO.refreshToken());
 
@@ -86,7 +86,8 @@ public class UserController {
 
     // 사용자 정보 수정하기
     @PatchMapping("/users")
-    public ResponseEntity<?> updateUser(@RequestBody UserRequest.UpdateUserDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> updateUser(@RequestBody @Valid UserRequest.UpdateUserDTO requestDTO, Errors errors,
+                                        @AuthenticationPrincipal CustomUserDetails userDetails) {
         userService.updateUser(requestDTO, userDetails.getUser().getId());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }


### PR DESCRIPTION
## 변경사항

TIL 관련해 코드 리팩토링을 진행했습니다. 
그리고 자잘자잘한 예외나 에러 처리를 했습니다. 

로드맵 생성할 때 로드맵 생성한 사람은 isAccept가 null로 들어가 권한 처리에 막히는 부분은 생성자는 UserRoadmap에서 isAccept를 true로 저장해 해결했습니다. 
또한 그룹 roadmap에 신청해서 허가 받은 사람들은 UserStep에 저장되었지만, 그룹 roadmap을 생성할 때 생성자에 대해 각 step에 대한 정보는 UserStep에 저장이 안됐습니다. 그래서 해당 부분을 추가했습니다. (원래 생성한 사람은 UserStep에 넣지 않아서 생성자는 step에 대해 제출을 못하는 상태였습니다.)

## 체크리스트

- [x] TilController 리팩토링
- [x] TilService 내 예외 처리 
- [x] TilSercvice 리팩토링
- [x] Til 관련 DTO validation 적용 및 수정 
- [x] roadmap 생성 시 UserStep 저장

## 논의하고 싶은점

공통적으로 사용되는 코드는 private 한 메서드로 분리했는데 직관적으로 알 수 있게 네이밍하려 했습니다. 혹시 메서드명에서 바로 기능을 모르겠거나, 어색한 부분이 있으면 말해주세요!

## Linked Issues

closes #84 
