### PR TITLE
ROADMAP 예외 처리 및 리팩토링

### DIFF
--- a/src/main/java/com/example/tily/_core/errors/exception/ExceptionCode.java
+++ b/src/main/java/com/example/tily/_core/errors/exception/ExceptionCode.java
@@ -30,6 +30,7 @@ public enum ExceptionCode {
     TIL_SUBMIT_FORBIDDEN(HttpStatus.FORBIDDEN, "til을 제출할 권한이 없습니다."),
     TIL_ALREADY_SUBMIT(HttpStatus.BAD_REQUEST, "이미 til을 제출하였습니다."),
     TIL_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 til을 삭제할 권한이 없습니다."),
+    TIL_END_DUEDATE(HttpStatus.BAD_REQUEST, "제출 시간이 지나 til을 제출할 수 없습니다."),
 
     // roadmap 관련 에러
     ROADMAP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 roadmap을 찾을 수 없습니다."),
@@ -40,6 +41,8 @@ public enum ExceptionCode {
     ROADMAP_ALREADY_APPLY(HttpStatus.BAD_REQUEST, "해당 로드맵에 이미 신청했습니다."),
     ROADMAP_REJECT(HttpStatus.BAD_REQUEST, "로드맵 신청이 거절되었습니다."),
     ROADMAP_ALREADY_MEMBER(HttpStatus.BAD_REQUEST, "이미 해당 로드맵에 속했습니다."),
+    ROADMAP_DISMISS_FORBIDDEN(HttpStatus.FORBIDDEN, "로드맵의 master를 강퇴할 권한이 없습니다."),
+    ROADMAP_ONLY_MASTER(HttpStatus.FORBIDDEN, "master 권한이 필요합니다."),
 
     // step 관련 에러
     STEP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 step을 찾을 수 없습니다."),

--- a/src/main/java/com/example/tily/roadmap/Roadmap.java
+++ b/src/main/java/com/example/tily/roadmap/Roadmap.java
@@ -21,10 +21,7 @@ public class Roadmap extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-//    @OneToMany(mappedBy =  "roadmap")
-//    private List<UserRoadmap> userRoadmaps = new ArrayList<>();
-
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creator_id")
     private User creator;
 

--- a/src/main/java/com/example/tily/roadmap/RoadmapController.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapController.java
@@ -5,6 +5,7 @@ import com.example.tily._core.utils.ApiUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -16,17 +17,17 @@ public class RoadmapController {
 
     // 개인 로드맵(카테고리) 생성하기
     @PostMapping("/roadmaps/individual")
-    public ResponseEntity<?> createIndividualRoadmap(@RequestBody @Valid RoadmapRequest.CreateIndividualRoadmapDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> createIndividualRoadmap(@RequestBody @Valid RoadmapRequest.CreateIndividualRoadmapDTO requestDTO, Errors errors,
+                                                     @AuthenticationPrincipal CustomUserDetails userDetails) {
         RoadmapResponse.CreateRoadmapDTO responseDTO = roadmapService.createIndividualRoadmap(requestDTO, userDetails.getUser());
-
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
     // 그룹 로드맵 생성하기
     @PostMapping("/roadmaps")
-    public ResponseEntity<?> createGroupRoadmap(@RequestBody @Valid RoadmapRequest.CreateGroupRoadmapDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<?> createGroupRoadmap(@RequestBody @Valid RoadmapRequest.CreateGroupRoadmapDTO requestDTO, Errors errors,
+                                                @AuthenticationPrincipal CustomUserDetails userDetails){
         RoadmapResponse.CreateRoadmapDTO responseDTO = roadmapService.createGroupRoadmap(requestDTO, userDetails.getUser());
-
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
@@ -34,21 +35,20 @@ public class RoadmapController {
     @GetMapping("/roadmaps/{id}")
     public ResponseEntity<?> findGroupRoadmap(@PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails){
          RoadmapResponse.FindGroupRoadmapDTO responseDTO = roadmapService.findGroupRoadmap(id, userDetails.getUser());
-
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
     // 그룹 로드맵 정보 수정하기
     @PostMapping("/roadmaps/{id}")
-    public ResponseEntity<?> updateGroupRoadmap(@PathVariable Long id, @RequestBody @Valid RoadmapRequest.UpdateGroupRoadmapDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<?> updateGroupRoadmap(@RequestBody @Valid RoadmapRequest.UpdateGroupRoadmapDTO requestDTO, Errors errors,
+                                                @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails){
         roadmapService.updateGroupRoadmap(id, requestDTO, userDetails.getUser());
-
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
     // 내가 속한 로드맵 전체 목록 조회하기
     @GetMapping("/roadmaps/my")
-    public ResponseEntity<?> findAllMyRoadmap(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<?> findAllMyRoadmaps(@AuthenticationPrincipal CustomUserDetails userDetails) {
         RoadmapResponse.FindAllMyRoadmapDTO responseDTO = roadmapService.findAllMyRoadmaps(userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
@@ -58,7 +58,7 @@ public class RoadmapController {
     public ResponseEntity<?> findRoadmapByQuery(@RequestParam(value="category", defaultValue = "tily") String category,
                                                 @RequestParam(value="name", required = false) String name,
                                                 @RequestParam(value="page", defaultValue = "0") int page,
-                                                @RequestParam(value="size", defaultValue = "9") int size,
+                                                @RequestParam(value="size", defaultValue = "12") int size,
                                                 @AuthenticationPrincipal CustomUserDetails userDetails) {
         RoadmapResponse.FindRoadmapByQueryDTO responseDTO  = roadmapService.findAll(category, name, page, size);
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
@@ -66,76 +66,71 @@ public class RoadmapController {
 
     // 특정 로드맵에 참여 신청하기
     @PostMapping("/roadmaps/{id}/apply")
-    public ResponseEntity<?> applyRoadmap(@RequestBody @Valid RoadmapRequest.ApplyRoadmapDTO requestDTO, @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<?> applyRoadmap(@RequestBody @Valid RoadmapRequest.ApplyRoadmapDTO requestDTO, Errors errors,
+                                          @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails){
         roadmapService.applyRoadmap(requestDTO, id, userDetails.getUser());
-
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
     // 참가 코드로 로드맵 참여하기
     @PostMapping("/roadmaps/groups/participate")
-    public ResponseEntity<?> participateRoadmap(@RequestBody @Valid RoadmapRequest.ParticipateRoadmapDTO requestDTO, @AuthenticationPrincipal CustomUserDetails userDetails){
+    public ResponseEntity<?> participateRoadmap(@RequestBody @Valid RoadmapRequest.ParticipateRoadmapDTO requestDTO, Errors errors,
+                                                @AuthenticationPrincipal CustomUserDetails userDetails){
         RoadmapResponse.ParticipateRoadmapDTO responseDTO = roadmapService.participateRoadmap(requestDTO, userDetails.getUser());
-
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
     // 로드맵의 구성원 전체 조회하기
-    @GetMapping("/roadmaps/groups/{id}/members")
-    public ResponseEntity<?> findRoadmapMembers(@PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails){
-        RoadmapResponse.FindRoadmapMembersDTO responseDTO = roadmapService.findRoadmapMembers(id, userDetails.getUser());
-
+    @GetMapping("/roadmaps/groups/{groupId}/members")
+    public ResponseEntity<?> findRoadmapMembers(@PathVariable Long groupId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        RoadmapResponse.FindRoadmapMembersDTO responseDTO = roadmapService.findRoadmapMembers(groupId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
     // 로드맵의 구성원 역할 바꾸기
-    @PatchMapping("/roadmaps/groups/{groupsId}/members/{membersId}")
-    public ResponseEntity<?> changeMemberRole(@RequestBody @Valid RoadmapRequest.ChangeMemberRoleDTO requestDTO, @PathVariable Long groupsId, @PathVariable Long membersId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        roadmapService.changeMemberRole(requestDTO, groupsId, membersId, userDetails.getUser());
-
+    @PatchMapping("/roadmaps/groups/{groupId}/members/{memberId}")
+    public ResponseEntity<?> changeMemberRole(@RequestBody @Valid RoadmapRequest.ChangeMemberRoleDTO requestDTO, Errors errors,
+                                              @PathVariable Long groupId, @PathVariable Long memberId,
+                                              @AuthenticationPrincipal CustomUserDetails userDetails){
+        roadmapService.changeMemberRole(requestDTO, groupId, memberId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
     // 로드맵의 구성원 강퇴하기
-    @DeleteMapping("/roadmaps/groups/{groupsId}/members/{membersId}")
-    public ResponseEntity<?> dismissMember(@PathVariable Long groupsId, @PathVariable Long membersId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        roadmapService.dismissMember(groupsId, membersId, userDetails.getUser());
-
+    @DeleteMapping("/roadmaps/groups/{groupId}/members/{memberId}")
+    public ResponseEntity<?> dismissMember(@PathVariable Long groupId, @PathVariable Long memberId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        roadmapService.dismissMember(groupId, memberId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
     // 로드맵에 신청한 사람들 목록 조회하기
-    @GetMapping("/roadmaps/groups/{id}/members/apply")
-    public ResponseEntity<?> findAppliedUsers(@PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails){
-        RoadmapResponse.FindAppliedUsersDTO responseDTO = roadmapService.findAppliedUsers(id, userDetails.getUser());
-
+    @GetMapping("/roadmaps/groups/{groupId}/members/apply")
+    public ResponseEntity<?> findAppliedUsers(@PathVariable Long groupId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        RoadmapResponse.FindAppliedUsersDTO responseDTO = roadmapService.findAppliedUsers(groupId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
     // 로드맵 참여 신청 승인
-    @PostMapping("/roadmaps/groups/{groupsId}/members/{membersId}/accept")
-    public ResponseEntity<?> acceptApplication(@PathVariable Long groupsId, @PathVariable Long membersId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        roadmapService.acceptApplication(groupsId, membersId, userDetails.getUser());
-
+    @PostMapping("/roadmaps/groups/{groupId}/members/{memberId}/accept")
+    public ResponseEntity<?> acceptApplication(@PathVariable Long groupId, @PathVariable Long memberId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        roadmapService.acceptApplication(groupId, memberId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
     // 로드맵 참여 신청 거절
-    @DeleteMapping("/roadmaps/groups/{groupsId}/members/{membersId}/reject")
-    public ResponseEntity<?> rejectApplication(@PathVariable Long groupsId, @PathVariable Long membersId, @AuthenticationPrincipal CustomUserDetails userDetails){
-        roadmapService.rejectApplication(groupsId, membersId, userDetails.getUser());
-
+    @DeleteMapping("/roadmaps/groups/{groupId}/members/{memberId}/reject")
+    public ResponseEntity<?> rejectApplication(@PathVariable Long groupId, @PathVariable Long memberId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        roadmapService.rejectApplication(groupId, memberId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 
     //  로드맵의 특정 step의 틸 목록 조회
-    @GetMapping("/roadmaps/groups/{groupsId}/steps/{stepsId}/tils")
-    public ResponseEntity<?> findTilOfStep(@PathVariable Long groupsId, @PathVariable Long stepsId,
+    @GetMapping("/roadmaps/groups/{groupId}/steps/{stepId}/tils")
+    public ResponseEntity<?> findTilOfStep(@PathVariable Long groupId, @PathVariable Long stepId,
                                            @RequestParam(value="isSubmit", defaultValue = "true") Boolean isSubmit,
                                            @RequestParam(value="isMember", defaultValue = "true") Boolean isMember,
                                            @RequestParam(value="name", required = false) String name){
-
-        RoadmapResponse.FindTilOfStepDTO responseDTO = roadmapService.findTilOfStep(groupsId, stepsId, isSubmit, isMember, name);
+        RoadmapResponse.FindTilOfStepDTO responseDTO = roadmapService.findTilOfStep(groupId, stepId, isSubmit, isMember, name);
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapRepository.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapRepository.java
@@ -15,7 +15,11 @@ public interface RoadmapRepository extends JpaRepository<Roadmap, Long> {
     @Query("select r from Roadmap r where r.creator.id =:userId and r.category=:category")
     List<Roadmap> findByUserId(@Param("userId") Long userId, @Param("category") Category category);
 
-    @Query("select r from Roadmap r where r.category=:category and (:name is null or r.name=:name) and (r.isPublic=true or r.isPublic is null) and (r.isRecruit=true or r.isRecruit is null)")
+    @Query("select r from Roadmap r " +
+            "where r.category=:category " +
+            "and (:name is null or r.name like %:name%) " +
+            "and (r.isPublic=true or r.isPublic is null) " +
+            "and (r.isRecruit=true or r.isRecruit is null)")
     Slice<Roadmap> findAllByOrderByCreatedDateDesc(@Param("category") Category category, @Param("name") String name, Pageable pageable);
 
     Optional<Roadmap> findByCode(String code);

--- a/src/main/java/com/example/tily/roadmap/RoadmapRequest.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapRequest.java
@@ -36,10 +36,10 @@ public class RoadmapRequest {
     }
 
     public record ParticipateRoadmapDTO(@NotBlank(message="이름을 입력해주세요.")
-                                        @Size(min=8, max=8, message = "코드는 8자여야 합니다.")String code){
+                                        @Size(min=8, max=8, message = "코드는 8자여야 합니다.") String code){
     }
 
-    public record ChangeMemberRoleDTO(@NotNull(message="역할을 선택해주세요.") GroupRole role){
+    public record ChangeMemberRoleDTO(@NotNull(message="역할을 선택해주세요.") String role){
     }
 }
 

--- a/src/main/java/com/example/tily/roadmap/RoadmapRequest.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapRequest.java
@@ -4,6 +4,7 @@ import com.example.tily.roadmap.relation.GroupRole;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -23,8 +24,14 @@ public class RoadmapRequest {
     public record RoadmapDTO(@NotBlank(message = "이름을 입력해주세요.") String name, String description, String code, Boolean isPublic, Boolean isRecruit){
     }
 
-    public record StepDTO(Long id, @NotBlank(message = "제목을 입력해주세요.") String title, String description, ReferenceDTOs references, LocalDateTime dueDate){
-    }
+    public record StepDTO(
+            Long id,
+            @NotBlank(message = "제목을 입력해주세요.")
+            String title,
+            String description,
+            ReferenceDTOs references,
+            @Pattern(regexp = "^[0-9]{4}+-[0-9]{2}+-[0-9]{2}+( )+[0-9]{2}+:[0-9]{2}+:[0-9]{2}$", message = "잘못된 날짜 형식입니다.")
+            String dueDate) {}
 
     public record ReferenceDTOs(List<ReferenceDTO> youtube, List<ReferenceDTO> web) {
     }

--- a/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
@@ -1,12 +1,16 @@
 package com.example.tily.roadmap;
 
 import com.example.tily.roadmap.relation.GroupRole;
+import com.example.tily.roadmap.relation.UserRoadmap;
 import com.example.tily.step.Step;
 import com.example.tily.step.reference.Reference;
+import com.example.tily.til.Til;
 import com.example.tily.user.Role;
 import com.example.tily.user.User;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 
@@ -17,16 +21,17 @@ public class RoadmapResponse {
         }
     }
 
-    public record FindGroupRoadmapDTO(Creator creator, String name, String description, Role role, Long recentTilId, String code, List<StepDTO> steps) {
-        public FindGroupRoadmapDTO(Roadmap roadmap, List<StepDTO> steps, User user, Long recentTilId) {
-            this(new Creator(user.getName(), user.getImage()), roadmap.getName(), roadmap.getDescription(), user.getRole(), recentTilId, roadmap.getCode(), steps);
+    public record FindGroupRoadmapDTO(Creator creator, String name, String description, String myRole, Long recentTilId, Long recentStepId, Boolean isPublic, Boolean isRecruit, String code, List<StepDTO> steps) {
+        public FindGroupRoadmapDTO(Roadmap roadmap, List<StepDTO> steps, User user, Long recentTilId, Long recentStepId, String myRole) {
+            this(new Creator(user.getName(), user.getImage()), roadmap.getName(), roadmap.getDescription(), myRole, recentTilId, recentStepId, roadmap.getIsPublic(), roadmap.getIsRecruit(), roadmap.getCode(), steps);
         }
 
         public record Creator(String name, String image) {}
 
-        public record StepDTO(Long id, String title, String description, ReferenceDTOs references) {
+        public record StepDTO(Long id, String title, String description, String dueDate, ReferenceDTOs references) {
+
             public StepDTO(Step step, List<ReferenceDTOs.ReferenceDTO> youtubeList, List<ReferenceDTOs.ReferenceDTO> webList) {
-                this(step.getId(), step.getTitle(), step.getDescription(), new ReferenceDTOs(youtubeList, webList));
+                this(step.getId(), step.getTitle(), step.getDescription(), step.getDueDate()!=null ? DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").format(step.getDueDate()) : null, new ReferenceDTOs(youtubeList, webList));
             }
         }
     }

--- a/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
@@ -90,15 +90,31 @@ public class RoadmapResponse {
         }
     }
 
-    public record FindRoadmapMembersDTO(List<UserDTO> users, GroupRole myRole) {
-        public record UserDTO(Long id, String name, String image, GroupRole role) {}
+    public record FindRoadmapMembersDTO(List<UserDTO> users) {
+        public record UserDTO(Long id, String name, String image, String role) {}
     }
 
-    public record FindAppliedUsersDTO(List<UserDTO> users, GroupRole myRole) {
-        public record UserDTO(Long id, String name, String image, LocalDate date, String content) {}
+    public record FindAppliedUsersDTO(List<UserDTO> users) {
+        public record UserDTO(Long id, String name, String image, LocalDate date, String content) {
+            public UserDTO(User user, UserRoadmap userRoadmap) {
+                this(user.getId(), user.getName(), user.getImage(), userRoadmap.getCreatedDate().toLocalDate(), userRoadmap.getContent());
+            }
+        }
     }
 
     public record FindTilOfStepDTO(List<MemberDTO> members) {
-        public record MemberDTO(Long tilId, Long userId, String name, String image, String content, LocalDate submitDate, int commentNum) {}
+        public record MemberDTO(Long tilId, Long userId, String name, String image, String content, String submitDate, Integer commentNum) {
+
+            public MemberDTO(Til til, User user) {
+                this(
+                        til!=null ? til.getId() : null,
+                        user.getId(),
+                        user.getName(),
+                        user.getImage(),
+                        til!=null ? til.getContent() : null,
+                        til!=null ? til.getSubmitDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) : null,
+                        til!=null ? til.getCommentNum() : null);
+            }
+        }
     }
 }

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -79,11 +79,12 @@ public class RoadmapService {
 
         for(RoadmapRequest.StepDTO stepDTO : stepDTOS){
             // step 저장
-            String title = stepDTO.title() ;
-            String stepDescription = stepDTO.description();
-            LocalDateTime dueDate =  stepDTO.dueDate();
-
-            Step step = Step.builder().roadmap(roadmap).title(title).description(stepDescription).dueDate(dueDate).build();
+            Step step = Step.builder()
+                    .roadmap(roadmap)
+                    .title(stepDTO.title())
+                    .description(stepDTO.description())
+                    .dueDate(stepDTO.dueDate()!=null ? parseDate(stepDTO.dueDate()) : null)
+                    .build();
             stepRepository.save(step);
 
             UserStep userStep = UserStep.builder().roadmap(roadmap).step(step).user(user).isSubmit(false).build();

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -169,7 +169,23 @@ public class RoadmapService {
                         .collect(Collectors.toList())))
                 .collect(Collectors.toList());
 
-        return new RoadmapResponse.FindGroupRoadmapDTO(roadmap, steps, user, recentTilId);
+        Optional<UserRoadmap> userRoadmap = userRoadmapRepository.findByRoadmapIdAndUserIdAndIsAcceptTrue(id, user.getId());
+        String myRole;
+        Long recentTilId;
+        Long recentStepId;
+
+        if (userRoadmap.isPresent()) {
+            myRole = userRoadmap.get().getRole();
+            List<Til> tils = tilRepository.findByUserIdByOrderByUpdatedDateDesc(id, user.getId());
+            recentTilId = !tils.isEmpty() ? tils.get(0).getId() : null;
+            recentStepId = !tils.isEmpty() ? tils.get(0).getStep().getId() : null;
+        } else {
+            myRole = "none";
+            recentTilId = null;
+            recentStepId = null;
+        }
+
+        return new RoadmapResponse.FindGroupRoadmapDTO(roadmap, steps, roadmap.getCreator(), recentTilId, recentStepId, myRole);
     }
 
     @Transactional

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -387,13 +387,15 @@ public class RoadmapService {
 
     @Transactional
     public void dismissMember(Long groupsId, Long membersId, User user){
-        checkManagerPermission(groupsId, user);
+        String role = checkMasterAndManagerPermission(groupsId, user);
 
-        UserRoadmap userRoadmap = userRoadmapRepository.findByRoadmapIdAndUserIdAndIsAcceptTrue(groupsId, membersId)
-                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
+        UserRoadmap userRoadmap = getUserBelongRoadmap(groupsId, membersId);
 
-        // 방출하면 Role을 NONE으로
-        userRoadmap.updateRole(GroupRole.ROLE_NONE);
+        // master는 다 강퇴 가능, manager는 member만
+        if (role.equals(GroupRole.ROLE_MANAGER.getValue()) & userRoadmap.getRole().equals(GroupRole.ROLE_MASTER.getValue()))
+            throw new CustomException(ExceptionCode.ROADMAP_DISMISS_FORBIDDEN);
+
+        userRoadmap.updateRole(GroupRole.ROLE_NONE.getValue());
     }
 
     @Transactional

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -334,6 +334,10 @@ public class RoadmapService {
         Roadmap roadmap = roadmapRepository.findByCode(code)
                 .orElseThrow(() -> new CustomException(ExceptionCode.ROADMAP_NOT_FOUND));
 
+        Optional<UserRoadmap> ur = userRoadmapRepository.findByRoadmapIdAndUserIdAndIsAcceptTrue(roadmap.getId(), user.getId());
+        if (ur.isPresent())
+            throw new CustomException(ExceptionCode.ROADMAP_ALREADY_MEMBER);
+
         // 코드로 참여시 승인없이 바로 맴버가 된다
         UserRoadmap userRoadmap = UserRoadmap.builder()
                 .roadmap(roadmap)

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmap.java
@@ -29,10 +29,13 @@ public class UserRoadmap extends BaseTimeEntity {
 
     @Column(columnDefinition="TEXT", length = 1000)
     private String content;
+
     @Column
     private Boolean isAccept;
+
     @Column(nullable = false)
-    private GroupRole role;
+    private String role;
+
     @Column(nullable = false)
     private int progress;
 
@@ -42,11 +45,11 @@ public class UserRoadmap extends BaseTimeEntity {
         this.user = user;
         this.content = content;
         this.isAccept = isAccept;
-        this.role = role;
+        this.role = role.getValue();
         this.progress = progress;
     }
 
-    public void updateRole(GroupRole role) { this.role = role; }
+    public void updateRole(String role) { this.role = role; }
 
     public void updateIsAccept(Boolean isAccept) { this.isAccept = isAccept; }
 

--- a/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
+++ b/src/main/java/com/example/tily/roadmap/relation/UserRoadmapRepository.java
@@ -11,16 +11,19 @@ import java.util.Optional;
 public interface UserRoadmapRepository extends JpaRepository<UserRoadmap, Long> {
 
     @Query("select ur.roadmap from UserRoadmap ur where ur.user.id=:userId and (ur.isAccept=:isAccept or ur.isAccept=null)")
-    List<Roadmap> findByUserId(@Param("userId") Long userId, @Param("isAccept") Boolean isAccept);
+    List<Roadmap> findByUserIdAndIsAccept(@Param("userId") Long userId, @Param("isAccept") Boolean isAccept);
 
     List<UserRoadmap> findByRoadmapIdAndIsAcceptTrue(Long roadmapId);
 
-    List<UserRoadmap> findByRoadmapIdAndIsAcceptFalse(Long roadmapId);
+    List<UserRoadmap> findByRoadmapIdAndIsAcceptFalseAndRole(Long roadmapId, String role);
 
     Optional<UserRoadmap> findByRoadmapIdAndUserIdAndIsAcceptTrue(Long roadmapId, Long userId);
 
     Optional<UserRoadmap> findByRoadmapIdAndUserIdAndIsAcceptFalse(Long roadmapId, Long userId);
 
     @Query("select ur from UserRoadmap ur where ur.roadmap.id=:roadmapId and ur.user.id=:userId")
-    Optional<UserRoadmap> findByRoadmapIdAndUserId(@Param("roadmapId") Long roadmapId,@Param("userId") Long userId);
+    Optional<UserRoadmap> findByRoadmapIdAndUserId(@Param("roadmapId") Long roadmapId, @Param("userId") Long userId);
+
+    @Query("select ur from UserRoadmap ur where ur.roadmap.id=:roadmapId and (:name is null or ur.user.name like %:name%)")
+    List<UserRoadmap> findByRoadmapIdAndIsAcceptTrueAndName(@Param("roadmapId") Long roadmapId, @Param("name") String name);
 }

--- a/src/main/java/com/example/tily/step/StepService.java
+++ b/src/main/java/com/example/tily/step/StepService.java
@@ -87,7 +87,7 @@ public class StepService {
 
         // 해당 페이지로 들어온 사람의 역할 (master, manager, member, none)
         Optional<UserRoadmap> userRoadmap = userRoadmapRepository.findByRoadmapIdAndUserIdAndIsAcceptTrue(roadmapId, user.getId());
-        String role = userRoadmap.isPresent() ? userRoadmap.get().getRole().getValue() : "none";
+        String role = userRoadmap.isPresent() ? userRoadmap.get().getRole() : "none";
         int progress = userRoadmap.isPresent() ? userRoadmap.get().getProgress() : 0;
 
         List<StepResponse.FindAllStepDTO.StepDTO> stepDTOs = steps.stream()

--- a/src/main/java/com/example/tily/step/relation/UserStepRepository.java
+++ b/src/main/java/com/example/tily/step/relation/UserStepRepository.java
@@ -10,8 +10,16 @@ import java.util.Optional;
 public interface UserStepRepository extends JpaRepository<UserStep, Long> {
 
     Optional<UserStep> findByUserIdAndStepId(Long userId, Long stepId);
+
     List<UserStep> findByUserIdAndRoadmapId(Long userId, Long roadmapId);
 
-    @Query("select us from UserStep us where us.step.id=:stepId")
-    UserStep findByStepId(@Param("stepId") Long stepId);
+    @Query("select us from UserStep us " +
+            "where us.step.id=:stepId " +
+            "and us.isSubmit=:isSubmit " +
+            "and (:name is null or us.user.name like %:name%)")
+    List<UserStep> findAllByStepIdAndIsSubmitAndName(@Param("stepId") Long stepId,
+                                                     @Param("isSubmit") boolean isSubmit,
+                                                     @Param("name") String name);
+
+    Optional<UserStep> findByStepIdAndUserIdAndIsSubmitTrue(Long stepId, Long userId);
 }

--- a/src/main/java/com/example/tily/til/TilRepository.java
+++ b/src/main/java/com/example/tily/til/TilRepository.java
@@ -14,8 +14,10 @@ import java.util.Optional;
 
 public interface TilRepository extends JpaRepository<Til, Long>{
 
-    Til findFirstByOrderBySubmitDateDesc();
+    Til findFirstByOrderByUpdatedDateDesc();
 
+    @Query("select t from Til t where t.writer.id=:userId and t.roadmap.id=:roadmapId order by t.updatedDate desc")
+    List<Til> findByUserIdByOrderByUpdatedDateDesc(@Param("roadmapId") Long roadmapId, @Param("userId") Long userId);
     @Query("select t from Til t join fetch t.writer where t.id=:id")
     Optional<Til> findById(Long id);
 
@@ -38,7 +40,7 @@ public interface TilRepository extends JpaRepository<Til, Long>{
                                                @Param("title") String title,
                                                Pageable pageable);
 
-    List<Til> findByStep_Id(Long stepId);
+    List<Til> findByStepId(Long stepId);
 
     @Query("select t from Til t where t.writer.id=:userId and t.step.id=:stepId")
     Til findByStepIdAndUserId(@Param("stepId") Long stepId, @Param("userId") Long userId);

--- a/src/main/java/com/example/tily/til/TilResponse.java
+++ b/src/main/java/com/example/tily/til/TilResponse.java
@@ -22,9 +22,9 @@ public class TilResponse {
         }
     }
 
-    public record ViewDTO(String content, Boolean isPersonal, Boolean isSubmit, StepDTO step, List<CommentDTO> comments) {
+    public record ViewDTO(String content, Boolean isPersonal, Boolean isSubmit, String roadmapName, StepDTO step, List<CommentDTO> comments) {
         public ViewDTO(Step step, Til til, Boolean isSubmit, List<CommentDTO> comments) {
-            this(til.getContent(), til.isPersonal(), isSubmit, new StepDTO(step), comments);
+            this(til.getContent(), til.isPersonal(), isSubmit, step.getRoadmap().getName(), new StepDTO(step), comments);
         }
 
         public record StepDTO(Long id, String title) {

--- a/src/main/java/com/example/tily/til/TilService.java
+++ b/src/main/java/com/example/tily/til/TilService.java
@@ -130,6 +130,12 @@ public class TilService {
         if (userstep.getIsSubmit().equals(true))
             throw new CustomException(ExceptionCode.TIL_ALREADY_SUBMIT);
 
+        // 제출 시간 지났는데 제출하려고할때
+        LocalDateTime now = LocalDateTime.now();
+        if (now.isAfter(step.getDueDate()))
+            throw new CustomException(ExceptionCode.TIL_END_DUEDATE);
+
+
         til.submitTil(requestDTO.submitContent()); // 내용, 제출 내용 저장
         userstep.submit(); // 제출 여부(완료) 저장
         userRoadmap.updateProgress(calProgress(roadmapId, user.getId())); // 진도율 저장

--- a/src/test/java/com/example/tily/roadmap/RoadmapControllerTest.java
+++ b/src/test/java/com/example/tily/roadmap/RoadmapControllerTest.java
@@ -506,7 +506,7 @@ public class RoadmapControllerTest {
         // given
         Long groupsId = 12L;
         Long usersId = 2L;
-        RoadmapRequest.ChangeMemberRoleDTO requestDTO = new RoadmapRequest.ChangeMemberRoleDTO(GroupRole.ROLE_MANAGER);
+        RoadmapRequest.ChangeMemberRoleDTO requestDTO = new RoadmapRequest.ChangeMemberRoleDTO(GroupRole.ROLE_MANAGER.getValue());
 
         String requestBody = om.writeValueAsString(requestDTO);
 
@@ -528,7 +528,7 @@ public class RoadmapControllerTest {
         // given
         Long groupsId = 12L;
         Long usersId = 10L;
-        RoadmapRequest.ChangeMemberRoleDTO requestDTO = new RoadmapRequest.ChangeMemberRoleDTO(GroupRole.ROLE_MANAGER);
+        RoadmapRequest.ChangeMemberRoleDTO requestDTO = new RoadmapRequest.ChangeMemberRoleDTO(GroupRole.ROLE_MANAGER.getValue());
 
         String requestBody = om.writeValueAsString(requestDTO);
 
@@ -550,7 +550,7 @@ public class RoadmapControllerTest {
         // given
         Long groupsId = 20L;
         Long usersId = 2L;
-        RoadmapRequest.ChangeMemberRoleDTO requestDTO = new RoadmapRequest.ChangeMemberRoleDTO(GroupRole.ROLE_MANAGER);
+        RoadmapRequest.ChangeMemberRoleDTO requestDTO = new RoadmapRequest.ChangeMemberRoleDTO(GroupRole.ROLE_MANAGER.getValue());
 
         String requestBody = om.writeValueAsString(requestDTO);
 


### PR DESCRIPTION
## 변경사항

roadmap 관련 코드에서 예외처리 추가로 진행했습니다. 그리고 리팩토링도 했으나, 급하게 하느라 리팩토링이 되지 않은 부분이 있습니다. (주말에 리팩토링 예정)

예외 처리
- 로드맵에 신청하는 api (/roadmaps/{id}/apply) 에서 한 명이 여러번 신청 가능하고 또 신청 기록도 여러 번 나오는 상황을 위해 이미 신청 거절 당한 사람, 이미 로드맵에 속한 사람, 이미 신청한 사람에 대해 예외 처리를 했습니다.
- 또한 코드로 로드맵에 속하는 api (/roadmaps/groups/participate) 에서 이미 로드맵에 속한 사람에 대한 예외 처리를 추가했습니다.
- 로드맵의 member을 강퇴시키는 api (/roadmaps/groups/participate)에서 권한 처리를 추가했습니다. (master는 다 강퇴 가능, manager는 master 제외 강퇴 가능)
- 로드맵에 신청한 사람을 수락하는 api(/roadmaps/groups/{id}/members/{id}/accept) 에서 이미 거절당한 사람에 대한   수락 가능한 부분을 예외 처리 했습니다. 

수정 부분
- 로드맵에서 사용자의 권한 수정하는 api (/roadmaps/groups/{id}/members/{id})가 에러나서 (원인은 enum과 string 간 변환 작업이 없었습니다.) 그래서 UserRoadmap에서 role을 GroupRole의 value인 string으로 저장해 수정했습니다. 그리고 수정 권한은 master만 가능하도록 했습니다. 
-  로드맵 특정 step의 틸 목록 조회하는 api (/roadmaps/groups/{groupId}/steps/{stepId}/tils)가 동작하지 않아서 새로운 로직을 짰습니다. 급하게 짜느라 로직이 조금 지저분 할 수 있어서, 주말에 리팩토링할 예정입니다. 
- 로드맵 신청한 사람 조회하는 api (/roadmaps/groups/{id}/members/apply) 에서 기존에는 findByRoadmapIdAndIsAcceptFalse 로 조회를 해 거절당한 사람도 조회가 돼서 role도 추가로 조회해 신청한 사람만 조회했습니다.
- roadmap 정보 조회하는 api (/roadmaps/{id})에서 creator, myRole, isPublic, isSubmit, recentTilId, recentStepId을 추가로 DTO로 넘겼습니다. 이때 recentTil을 조회하는 코드는 리팩토링이 되지 않아 주말에 할 예정입니다. 
- 요청 DTO에 대해 valid 검사를 Errors로 잡아서 예외를 처리하게 수정했습니다. 

## 체크리스트

- [x] RoadmapController 리팩토링
- [x] RoadmapService 예외 처리 
- [x] RoadmapService 리팩토링

## 논의하고 싶은점

아직 로드맵 수정 api (/roadmaps/{id}) 는 프론트의 요구사항을 반영하지 않았습니다. 

## Linked Issues

closes #90 
