### PR TITLE
Tily 로드맵 신청 api 생성, group 로드맵 수정 api 수정

### DIFF
--- a/src/main/java/com/example/tily/TiLyApplication.java
+++ b/src/main/java/com/example/tily/TiLyApplication.java
@@ -281,11 +281,11 @@ public class TiLyApplication {
 				.build();
 	}
 
-	private Alarm newAlarm(Til til, User receiver, Boolean isChecked) {
+	private Alarm newAlarm(Til til, User receiver, Boolean isRead) {
 		return Alarm.builder()
 				.til(til)
 				.receiver(receiver)
-				.isChecked(false)
+				.isRead(false)
 				.build();
 	}
 

--- a/src/main/java/com/example/tily/_core/errors/exception/ExceptionCode.java
+++ b/src/main/java/com/example/tily/_core/errors/exception/ExceptionCode.java
@@ -45,6 +45,7 @@ public enum ExceptionCode {
     ROADMAP_ALREADY_MEMBER(HttpStatus.BAD_REQUEST, "이미 해당 로드맵에 속했습니다."),
     ROADMAP_DISMISS_FORBIDDEN(HttpStatus.FORBIDDEN, "로드맵의 master를 강퇴할 권한이 없습니다."),
     ROADMAP_ONLY_MASTER(HttpStatus.FORBIDDEN, "master 권한이 필요합니다."),
+    ROADMAP_END_RECRUIT(HttpStatus.BAD_REQUEST, "해당 로드맵은 모집을 종료했습니다."),
 
     // step 관련 에러
     STEP_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 step을 찾을 수 없습니다."),

--- a/src/main/java/com/example/tily/alarm/Alarm.java
+++ b/src/main/java/com/example/tily/alarm/Alarm.java
@@ -34,17 +34,17 @@ public class Alarm extends BaseTimeEntity {
     private Comment comment;
 
     @Column
-    private Boolean isChecked;
+    private Boolean isRead;
 
     @Builder
-    public Alarm(Til til, User receiver, Comment comment, Boolean isChecked) {
+    public Alarm(Til til, User receiver, Comment comment, Boolean isRead) {
         this.til = til;
         this.receiver = receiver;
         this.comment = comment;
-        this.isChecked = isChecked;
+        this.isRead = isRead;
     }
 
     public void readAlarm() {
-        this.isChecked = true;
+        this.isRead = true;
     }
 }

--- a/src/main/java/com/example/tily/alarm/AlarmRepository.java
+++ b/src/main/java/com/example/tily/alarm/AlarmRepository.java
@@ -12,7 +12,7 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     @Query("select a from Alarm a " +
             "join fetch a.til " +
             "join fetch a.comment " +
-            "where a.receiver.id=:receiverId and a.isChecked=false")
+            "where a.receiver.id=:receiverId")
     List<Alarm> findAllByReceiverId(@Param("receiverId") Long receiverId, Sort sort);
 
     void deleteByCommentId(Long commentId);

--- a/src/main/java/com/example/tily/alarm/AlarmResponse.java
+++ b/src/main/java/com/example/tily/alarm/AlarmResponse.java
@@ -28,7 +28,7 @@ public class AlarmResponse {
 
     public record AlarmDTO(Long id,
                            Long tilId,
-                           Boolean isChecked,
+                           Boolean isRead,
                            String createDate,
                            RoadmapDTO roadmap,
                            StepDTO step,
@@ -37,7 +37,7 @@ public class AlarmResponse {
         public AlarmDTO(Alarm alarm){
             this(alarm.getId(),
                     alarm.getTil().getId(),
-                    alarm.getIsChecked(),
+                    alarm.getIsRead(),
                     alarm.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")),
                     new RoadmapDTO(alarm.getTil().getRoadmap()),
                     new StepDTO(alarm.getTil().getStep()),

--- a/src/main/java/com/example/tily/comment/CommentService.java
+++ b/src/main/java/com/example/tily/comment/CommentService.java
@@ -45,7 +45,7 @@ public class CommentService {
         commentRepository.save(comment);
 
         // 댓글 작성하면 알림 생성
-        Alarm alarm = Alarm.builder().til(til).receiver(til.getWriter()).comment(comment).isChecked(false).build();
+        Alarm alarm = Alarm.builder().til(til).receiver(til.getWriter()).comment(comment).isRead(false).build();
         alarmRepository.save(alarm);
 
         return new CommentResponse.CreateCommentDTO(comment);

--- a/src/main/java/com/example/tily/roadmap/Roadmap.java
+++ b/src/main/java/com/example/tily/roadmap/Roadmap.java
@@ -60,12 +60,12 @@ public class Roadmap extends BaseTimeEntity {
         this.image = image;
     }
 
-    public void update(String name, String description, String code, Boolean isPublic, Boolean isRecruit){
-        this.name = name;
-        this.description = description;
-        this.code = code;
-        this.isPublic = isPublic;
-        this.isRecruit = isRecruit;
+    public void update(RoadmapRequest.RoadmapDTO roadmap){
+        this.name = roadmap.name();
+        this.description = roadmap.description();
+        this.code = roadmap.code();
+        this.isPublic = roadmap.isPublic();
+        this.isRecruit = roadmap.isRecruit();
     }
 
     public void updateImage (String image) {this.image = image; }

--- a/src/main/java/com/example/tily/roadmap/RoadmapController.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapController.java
@@ -72,11 +72,18 @@ public class RoadmapController {
         return ResponseEntity.ok().body(ApiUtils.success(responseDTO));
     }
 
-    // 특정 로드맵에 참여 신청하기
-    @PostMapping("/roadmaps/{id}/apply")
-    public ResponseEntity<?> applyRoadmap(@RequestBody @Valid RoadmapRequest.ApplyRoadmapDTO requestDTO, Errors errors,
-                                          @PathVariable Long id, @AuthenticationPrincipal CustomUserDetails userDetails){
-        roadmapService.applyRoadmap(requestDTO, id, userDetails.getUser());
+    // 그룹 로드맵에 참여 신청하기
+    @PostMapping("/roadmaps/groups/{groupId}/apply")
+    public ResponseEntity<?> applyGroupRoadmap(@RequestBody @Valid RoadmapRequest.ApplyRoadmapDTO requestDTO, Errors errors,
+                                          @PathVariable("groupId") Long groupId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        roadmapService.applyGroupRoadmap(requestDTO, groupId, userDetails.getUser());
+        return ResponseEntity.ok().body(ApiUtils.success(null));
+    }
+
+    // 틸리 로드맵에 참여 신청하기
+    @PostMapping("/roadmaps/tily/{tilyId}/apply")
+    public ResponseEntity<?> applyTilyRoadmap(@PathVariable("tilyId") Long tilyId, @AuthenticationPrincipal CustomUserDetails userDetails){
+        roadmapService.applyTilyRoadmap(tilyId, userDetails.getUser());
         return ResponseEntity.ok().body(ApiUtils.success(null));
     }
 

--- a/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
@@ -7,6 +7,7 @@ import com.example.tily.step.reference.Reference;
 import com.example.tily.til.Til;
 import com.example.tily.user.Role;
 import com.example.tily.user.User;
+import org.joda.time.DateTime;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -107,7 +108,7 @@ public class RoadmapResponse {
     }
 
     public record FindTilOfStepDTO(List<MemberDTO> members) {
-        public record MemberDTO(Long tilId, Long userId, String name, String image, String content, String submitDate, Integer commentNum) {
+        public record MemberDTO(Long tilId, Long userId, String name, String image, String content, LocalDateTime submitDate, Integer commentNum) {
 
             public MemberDTO(Til til, User user) {
                 this(
@@ -116,7 +117,7 @@ public class RoadmapResponse {
                         user.getName(),
                         user.getImage(),
                         til!=null ? til.getContent() : null,
-                        til!=null ? til.getSubmitDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")) : null,
+                        til!=null ? til.getSubmitDate() : null,
                         til!=null ? til.getCommentNum() : null);
             }
         }

--- a/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
@@ -90,8 +90,12 @@ public class RoadmapResponse {
         }
     }
 
-    public record FindRoadmapMembersDTO(List<UserDTO> users) {
-        public record UserDTO(Long id, String name, String image, String role) {}
+    public record FindRoadmapMembersDTO(String myRole, List<UserDTO> users) {
+        public record UserDTO(Long id, String name, String image, String role) {
+            public UserDTO(User user, String role) {
+                this(user.getId(), user.getName(), user.getImage(), role);
+            }
+        }
     }
 
     public record FindAppliedUsersDTO(List<UserDTO> users) {

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -418,15 +418,15 @@ public class RoadmapService {
     }
 
     public RoadmapResponse.FindRoadmapMembersDTO findRoadmapMembers(Long groupsId, User user){
-        checkMasterAndManagerPermission(groupsId, user);
+        String myRole = checkMasterAndManagerPermission(groupsId, user);
 
         List<UserRoadmap> userRoadmaps = userRoadmapRepository.findByRoadmapIdAndIsAcceptTrue(groupsId);
 
         List<RoadmapResponse.FindRoadmapMembersDTO.UserDTO> users = userRoadmaps.stream()
-                .map(userRoadmap -> new RoadmapResponse.FindRoadmapMembersDTO.UserDTO(userRoadmap.getUser().getId(), userRoadmap.getUser().getName(), userRoadmap.getUser().getImage(), userRoadmap.getRole()))
+                .map(userRoadmap -> new RoadmapResponse.FindRoadmapMembersDTO.UserDTO(userRoadmap.getUser(), userRoadmap.getRole()))
                 .collect(Collectors.toList());
 
-        return new RoadmapResponse.FindRoadmapMembersDTO(users);
+        return new RoadmapResponse.FindRoadmapMembersDTO(myRole, users);
     }
 
     @Transactional
@@ -499,39 +499,6 @@ public class RoadmapService {
 
     @Transactional
     public RoadmapResponse.FindTilOfStepDTO findTilOfStep(Long groupsId, Long stepId, Boolean isSubmit, Boolean isMember, String name){
-//        List<Pair<Til, User>> pairs = new ArrayList<>();
-//
-//        List<Til> tils = tilRepository.findByStepId(stepId);
-//        for(Til til : tils){
-//            User user = til.getWriter();
-//
-//            // 어떤 틸이 존재한다면, 해당 틸은 반드시 틸이 속한 Step과 Roadmap 그리고 User를 가진다 => userStep 관계와 userRoadmap 관계는 반드시 존재한다. => 존재하지 않은 것에 대한 예외처리 필요 X
-//            UserStep userStep = userStepRepository.findByUserIdAndStepId(user.getId(), stepId).get();
-//            UserRoadmap userRoadmap = userRoadmapRepository.findByRoadmapIdAndUserId(groupsId, user.getId()).get();
-//
-//            if((isSubmit == userStep.getIsSubmit())  && (name == null || name.equals(user.getName()))){
-//                // isMember가 false => 운영자를 포함해서 모든 til을 반환, isMember가 true => 운영자의 til을 제외하고 반환한다
-//                if(!isMember || (isMember && GroupRole.ROLE_MEMBER.equals(userRoadmap.getRole()))){
-//                    Pair<Til, User> pair = Pair.of(til, user);
-//                    pairs.add(pair);
-//                }
-//            }
-//        }
-//
-//        List<RoadmapResponse.FindTilOfStepDTO.MemberDTO> members;
-//
-//        if(isSubmit) {
-//            members = pairs.stream()
-//                    .map(pair -> new RoadmapResponse.FindTilOfStepDTO.MemberDTO(pair.getFirst().getId(), pair.getSecond().getId(),pair.getSecond().getName(), pair.getSecond().getImage(), pair.getFirst().getContent(), pair.getFirst().getSubmitDate().toLocalDate(), pair.getFirst().getCommentNum()))
-//                    .collect(Collectors.toList());
-//        }
-//        else {
-//            members = pairs.stream()
-//                    .map(pair -> new RoadmapResponse.FindTilOfStepDTO.MemberDTO(null, pair.getSecond().getId(), pair.getSecond().getName(), null, null, null, 0))
-//                    .collect(Collectors.toList());
-//        }
-//
-//        return new RoadmapResponse.FindTilOfStepDTO(members);
 
         // 특정 로드맵에 속한 UserRoadmap list
         List<UserRoadmap> userRoadmaps = userRoadmapRepository.findByRoadmapIdAndIsAcceptTrue(groupsId);

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -366,6 +366,29 @@ public class RoadmapService {
     }
 
     @Transactional
+    public void applyTilyRoadmap(Long id, User user) {
+        Roadmap roadmap = getRoadmapById(id);
+
+        // 모집을 중단했을 때
+        if (!roadmap.getIsRecruit())
+            throw new CustomException(ExceptionCode.ROADMAP_END_RECRUIT);
+
+        // 이미 로드맵에 속한 경우
+        Optional<UserRoadmap> ur = userRoadmapRepository.findByRoadmapIdAndUserId(id, user.getId());
+        if (ur.isPresent() && ur.get().getIsAccept().equals(true))
+                throw new CustomException(ExceptionCode.ROADMAP_ALREADY_MEMBER);
+
+        UserRoadmap userRoadmap = UserRoadmap.builder()
+                .roadmap(roadmap)
+                .user(user)
+                .role(GroupRole.ROLE_MEMBER)
+                .isAccept(true)
+                .progress(0)
+                .build();
+        userRoadmapRepository.save(userRoadmap);
+    }
+
+    @Transactional
     public RoadmapResponse.ParticipateRoadmapDTO participateRoadmap(RoadmapRequest.ParticipateRoadmapDTO requestDTO, User user){
         String code = requestDTO.code();
         Roadmap roadmap = roadmapRepository.findByCode(code)

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -339,8 +339,12 @@ public class RoadmapService {
     }
 
     @Transactional
-    public void applyRoadmap(RoadmapRequest.ApplyRoadmapDTO requestDTO, Long id, User user){
+    public void applyGroupRoadmap(RoadmapRequest.ApplyRoadmapDTO requestDTO, Long id, User user){
         Roadmap roadmap = getRoadmapById(id);
+
+        // 모집을 중단했을 때
+        if (!roadmap.getIsRecruit())
+            throw new CustomException(ExceptionCode.ROADMAP_END_RECRUIT);
 
         // 최초로 한 번만 신청 가능
         Optional<UserRoadmap> ur = userRoadmapRepository.findByRoadmapIdAndUserId(id, user.getId());

--- a/src/main/java/com/example/tily/user/UserService.java
+++ b/src/main/java/com/example/tily/user/UserService.java
@@ -30,6 +30,7 @@ public class UserService {
     private final JavaMailSender javaMailSender;
     private final RedisUtils redisUtils;
     private final TilRepository tilRepository;
+    private String defaultImage = "user/profile-user.jpg";
 
     // (회원가입) 이메일 중복 체크 후 인증코드 전송
     @Transactional
@@ -70,6 +71,7 @@ public class UserService {
                 .email(requestDTO.email())
                 .name(requestDTO.name())
                 .password(passwordEncoder.encode(requestDTO.password()))
+                .image(defaultImage)
                 .role(Role.ROLE_USER)
                 .build();
 


### PR DESCRIPTION
## 변경사항

tily 로드맵 신청 api를 만들었습니다. (/roadmaps/tily/{tilyId}/apply)
기존의 /roadmaps/{id}/apply api를 사용해 group 로드맵 신청 api와 합치려고 했으나, group 로드맵 신청은 신청서 내용이 요청으로 들어가, api를 분리했습니다. 
(/roadmaps/tily/{tilyId}/apply, /roadmaps/group/{tilyId}/apply)

그리고 그룹 로드맵 수정하기 api도 수정했습니다. (리팩토링 예졍)
Alarm 내 isChecked 필드를 isRead로 바꿨습니다. 이는 /alarms/read api와의 통일성을 위해 바꿨습니다. 
그리고 사용자가 회원 가입시 image에 기본 프로필 이미지를 넣었습니다. 

## 체크리스트

- [x] Tily 로드맵 신청 기능 구현
- [x] 로드맵 수정하기 api 수정
- [x] /alarm api 수정 
- [x] 사용자 기본 프로필 이미지 설정

## 논의하고 싶은점

## Linked Issues

closes #109 