### PR TITLE
댓글 삭제 권한 추가, 로드맵 속한 로직 추가

### DIFF
--- a/src/main/java/com/example/tily/alarm/AlarmRepository.java
+++ b/src/main/java/com/example/tily/alarm/AlarmRepository.java
@@ -12,7 +12,7 @@ public interface AlarmRepository extends JpaRepository<Alarm, Long> {
     @Query("select a from Alarm a " +
             "join fetch a.til " +
             "join fetch a.comment " +
-            "where a.receiver.id=:receiverId")
+            "where a.receiver.id=:receiverId and a.comment.writer.id!=:receiverId")
     List<Alarm> findAllByReceiverId(@Param("receiverId") Long receiverId, Sort sort);
 
     void deleteByCommentId(Long commentId);

--- a/src/main/java/com/example/tily/comment/CommentService.java
+++ b/src/main/java/com/example/tily/comment/CommentService.java
@@ -58,9 +58,8 @@ public class CommentService {
                 .orElseThrow(() -> new CustomException(ExceptionCode.COMMENT_NOT_FOUND));
 
 
-        if(!comment.getWriter().getId().equals(user.getId())) {
+        if(!comment.getWriter().getId().equals(user.getId()))
             throw new CustomException(ExceptionCode.COMMENT_UPDATE_FORBIDDEN);
-        }
 
         comment.updateComment(requestDTO.content());
     }
@@ -70,9 +69,9 @@ public class CommentService {
         Comment comment = commentRepository.findById(id)
                 .orElseThrow(() -> new CustomException(ExceptionCode.COMMENT_NOT_FOUND));
 
-        if(!comment.getWriter().getId().equals(user.getId())) {
+        // 댓글 주인 또는 글의 주인만 댓글 삭제 가능
+        if(!comment.getWriter().getId().equals(user.getId()) || !comment.getTil().getWriter().getId().equals(user.getId()))
             throw new CustomException(ExceptionCode.COMMENT_DELETE_FORBIDDEN);
-        }
 
         alarmRepository.deleteByCommentId(id);
         commentRepository.deleteById(id);

--- a/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapResponse.java
@@ -22,9 +22,9 @@ public class RoadmapResponse {
         }
     }
 
-    public record FindGroupRoadmapDTO(Creator creator, String name, String description, String myRole, Long recentTilId, Long recentStepId, Boolean isPublic, Boolean isRecruit, String code, List<StepDTO> steps) {
+    public record FindGroupRoadmapDTO(Creator creator, String name, String description, String myRole, Long recentTilId, Long recentStepId, Boolean isPublic, Boolean isRecruit, String code, String category, List<StepDTO> steps) {
         public FindGroupRoadmapDTO(Roadmap roadmap, List<StepDTO> steps, User user, Long recentTilId, Long recentStepId, String myRole) {
-            this(new Creator(user.getName(), user.getImage()), roadmap.getName(), roadmap.getDescription(), myRole, recentTilId, recentStepId, roadmap.getIsPublic(), roadmap.getIsRecruit(), roadmap.getCode(), steps);
+            this(new Creator(user.getName(), user.getImage()), roadmap.getName(), roadmap.getDescription(), myRole, recentTilId, recentStepId, roadmap.getIsPublic(), roadmap.getIsRecruit(), roadmap.getCode(), roadmap.getCategory().getValue(), steps);
         }
 
         public record Creator(String name, String image) {}
@@ -116,7 +116,7 @@ public class RoadmapResponse {
                         user.getId(),
                         user.getName(),
                         user.getImage(),
-                        til!=null ? til.getContent() : null,
+                        til!=null ? til.getSubmitContent() : null,
                         til!=null ? til.getSubmitDate() : null,
                         til!=null ? til.getCommentNum() : null);
             }

--- a/src/main/java/com/example/tily/roadmap/RoadmapService.java
+++ b/src/main/java/com/example/tily/roadmap/RoadmapService.java
@@ -139,7 +139,7 @@ public class RoadmapService {
                 .code(generateRandomCode())
                 .isRecruit(true)    // 모집여부
                 .stepNum(requestDTO.steps().size())
-                .image("https://tily-bucket.s3.ap-northeast-2.amazonaws.com/tily.png")
+                .image("tily.png")
                 .build();
         roadmapRepository.save(roadmap);
 
@@ -402,6 +402,18 @@ public class RoadmapService {
                 .progress(0)
                 .build();
         userRoadmapRepository.save(userRoadmap);
+
+        // 수강생이 해당 roadmap에 속한다 -> 제출 여부 관리를 위해 모든 step에 대해 userstep에 다 저장
+        List<Step> steps = stepRepository.findByRoadmapId(id);
+        for (Step step : steps) {
+            UserStep userStep = UserStep.builder()
+                    .roadmap(step.getRoadmap())
+                    .step(step)
+                    .user(userRoadmap.getUser())
+                    .isSubmit(false)
+                    .build();
+            userStepRepository.save(userStep);
+        }
     }
 
     @Transactional
@@ -423,8 +435,19 @@ public class RoadmapService {
                 .isAccept(true)
                 .progress(0)
                 .build();
-
         userRoadmapRepository.save(userRoadmap);
+
+        // 해당 roadmap에 속한다 -> 제출 여부 관리를 위해 모든 step에 대해 userstep에 다 저장
+        List<Step> steps = stepRepository.findByRoadmapId(roadmap.getId());
+        for (Step step : steps) {
+            UserStep userStep = UserStep.builder()
+                    .roadmap(step.getRoadmap())
+                    .step(step)
+                    .user(userRoadmap.getUser())
+                    .isSubmit(false)
+                    .build();
+            userStepRepository.save(userStep);
+        }
 
         return new RoadmapResponse.ParticipateRoadmapDTO(roadmap);
     }
@@ -540,6 +563,7 @@ public class RoadmapService {
 
         return new RoadmapResponse.FindTilOfStepDTO(members);
     }
+
 
     private static String generateRandomCode() {
         String upperAlphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";

--- a/src/main/java/com/example/tily/til/TilResponse.java
+++ b/src/main/java/com/example/tily/til/TilResponse.java
@@ -22,9 +22,9 @@ public class TilResponse {
         }
     }
 
-    public record ViewDTO(String content, Boolean isPersonal, Boolean isSubmit, String roadmapName, StepDTO step, List<CommentDTO> comments) {
+    public record ViewDTO(String content, String submitContent, Boolean isPersonal, Boolean isSubmit, String roadmapName, StepDTO step, List<CommentDTO> comments) {
         public ViewDTO(Step step, Til til, Boolean isSubmit, List<CommentDTO> comments) {
-            this(til.getContent(), til.isPersonal(), isSubmit, step.getRoadmap().getName(), new StepDTO(step), comments);
+            this(til.getContent(), til.getSubmitContent(), til.isPersonal(), isSubmit, step.getRoadmap().getName(), new StepDTO(step), comments);
         }
 
         public record StepDTO(Long id, String title) {


### PR DESCRIPTION
## 변경사항

댓글 삭제 권한을 추가했습니다. 글 작성자도 댓글 삭제 가능하게 했습니다.
그리고 알림 조회 시 자신이 자신의 글에 작성한 댓글에 대한 알림은 제외했습니다.
로드맵 신청해서 로드맵에 속한 경우 UserStep 에도 넣었습니다. (step별 제출 관리를 위한 테이블)

## 체크리스트

- [ ] comment 삭제 권한 추가
- [ ] alarm 쿼리 수정
- [ ] roadmap 속했을 때 로직 추가 

